### PR TITLE
feat(contract): 관리자 예치금 pending 배치로 관리자 예치금 부하 분리

### DIFF
--- a/contract-service/src/main/java/com/example/contractservice/common/controller/DomainExceptionHandler.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/controller/DomainExceptionHandler.java
@@ -3,6 +3,7 @@ package com.example.contractservice.common.controller;
 import static com.example.contractservice.contract.common.ResponseDtoMapper.getErrorResponse;
 
 import com.example.contractservice.common.domain.exception.DomainErrorCode;
+import com.example.contractservice.common.domain.exception.DomainException;
 import com.example.contractservice.contract.domain.exception.ContractException;
 import com.example.contractservice.deposit.domain.exception.DepositException;
 import org.hexagon.core.dto.Empty;
@@ -23,6 +24,13 @@ public class DomainExceptionHandler {
 
     @ExceptionHandler(DepositException.class)
     public ResponseEntity<ResponseDto<Empty>> handleDepositException(DepositException e) {
+        DomainErrorCode errorCode = e.getErrorCode();
+
+        return ResponseEntity.status(errorCode.getHttpStatusCode()).body(getErrorResponse(errorCode));
+    }
+
+    @ExceptionHandler(DomainException.class)
+    public ResponseEntity<ResponseDto<Empty>> handleDomainException(DomainException e) {
         DomainErrorCode errorCode = e.getErrorCode();
 
         return ResponseEntity.status(errorCode.getHttpStatusCode()).body(getErrorResponse(errorCode));

--- a/contract-service/src/main/java/com/example/contractservice/common/controller/DomainExceptionHandler.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/controller/DomainExceptionHandler.java
@@ -3,9 +3,9 @@ package com.example.contractservice.common.controller;
 import static com.example.contractservice.contract.common.ResponseDtoMapper.getErrorResponse;
 
 import com.example.contractservice.common.domain.exception.DomainErrorCode;
-import com.example.contractservice.common.domain.exception.DomainException;
 import com.example.contractservice.contract.domain.exception.ContractException;
 import com.example.contractservice.deposit.domain.exception.DepositException;
+import com.example.contractservice.settlement.domain.exception.SettlementException;
 import org.hexagon.core.dto.Empty;
 import org.hexagon.core.dto.ResponseDto;
 import org.springframework.http.ResponseEntity;
@@ -29,11 +29,10 @@ public class DomainExceptionHandler {
         return ResponseEntity.status(errorCode.getHttpStatusCode()).body(getErrorResponse(errorCode));
     }
 
-    @ExceptionHandler(DomainException.class)
-    public ResponseEntity<ResponseDto<Empty>> handleDomainException(DomainException e) {
+    @ExceptionHandler(SettlementException.class)
+    public ResponseEntity<ResponseDto<Empty>> handleSettlementException(SettlementException e) {
         DomainErrorCode errorCode = e.getErrorCode();
 
         return ResponseEntity.status(errorCode.getHttpStatusCode()).body(getErrorResponse(errorCode));
     }
-
 }

--- a/contract-service/src/main/java/com/example/contractservice/common/controller/GlobalExceptionHandler.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/controller/GlobalExceptionHandler.java
@@ -6,8 +6,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
+import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.hexagon.core.dto.ResponseDto;
 import org.hexagon.core.dto.Empty;
@@ -16,6 +18,7 @@ import org.hexagon.core.dto.Empty;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ResponseDto<Empty> handle(MethodArgumentNotValidException e) {
         String allExceptionMessages = e.getBindingResult().getAllErrors().stream().map(err -> err.getDefaultMessage())
                 .collect(Collectors.joining(" | "));
@@ -26,8 +29,9 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(BindException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ResponseDto<Empty> handle(BindException e) {
-        String bindingFailObjects = e.getBindingResult().getAllErrors().stream().map(err -> err.getObjectName())
+        String bindingFailObjects = e.getBindingResult().getAllErrors().stream().map(ObjectError::getObjectName)
                 .collect(Collectors.joining(", "));
 
         String message = StringUtil.format("잘못된 타입의 입력이 존재합니다. 다음을 확인하십시오: {}", bindingFailObjects);
@@ -36,6 +40,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ResponseDto<Empty> handle() {
         String message = "잘못된 타입의 입력이 있거나 입력 구조가 잘못되었습니다.";
 
@@ -43,6 +48,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ResponseDto<Empty> handle(Exception e) {
         log.error("알 수 없는 예외 발생. 빠른 확인 필요!", e);
 

--- a/contract-service/src/main/java/com/example/contractservice/common/controller/GlobalExceptionHandler.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/controller/GlobalExceptionHandler.java
@@ -18,12 +18,12 @@ import org.hexagon.core.dto.Empty;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ResponseDto<Empty> handle(MethodArgumentNotValidException e) {
         String allExceptionMessages = e.getBindingResult().getAllErrors().stream().map(err -> err.getDefaultMessage())
                 .collect(Collectors.joining(" | "));
 
-        String message = StringUtil.format("입력 값이 올바르지 않습니다. {}", allExceptionMessages);
+        String message = StringUtil.format("?낅젰 媛믪씠 ?щ컮瑜댁? ?딆뒿?덈떎. {}", allExceptionMessages);
 
         return new ResponseDto<>(4999, HttpStatus.BAD_REQUEST.value(), message, Empty.getInstance());
     }
@@ -34,7 +34,7 @@ public class GlobalExceptionHandler {
         String bindingFailObjects = e.getBindingResult().getAllErrors().stream().map(ObjectError::getObjectName)
                 .collect(Collectors.joining(", "));
 
-        String message = StringUtil.format("잘못된 타입의 입력이 존재합니다. 다음을 확인하십시오: {}", bindingFailObjects);
+        String message = StringUtil.format("?섎せ????낆쓽 ?낅젰??議댁옱?⑸땲?? ?ㅼ쓬???뺤씤?섏떗?쒖삤: {}", bindingFailObjects);
 
         return new ResponseDto<>(4999, HttpStatus.BAD_REQUEST.value(), message, Empty.getInstance());
     }
@@ -42,7 +42,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HttpMessageNotReadableException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ResponseDto<Empty> handle() {
-        String message = "잘못된 타입의 입력이 있거나 입력 구조가 잘못되었습니다.";
+        String message = "?섎せ????낆쓽 ?낅젰???덇굅???낅젰 援ъ“媛 ?섎せ?섏뿀?듬땲??";
 
         return new ResponseDto<>(4999, HttpStatus.BAD_REQUEST.value(), message, Empty.getInstance());
     }
@@ -50,7 +50,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ResponseDto<Empty> handle(Exception e) {
-        log.error("알 수 없는 예외 발생. 빠른 확인 필요!", e);
+        log.error("?????녿뒗 ?덉쇅 諛쒖깮. 鍮좊Ⅸ ?뺤씤 ?꾩슂!", e);
 
         return ResponseDto.fail();
     }

--- a/contract-service/src/main/java/com/example/contractservice/common/controller/GlobalExceptionHandler.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/controller/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package com.example.contractservice.common.controller;
 import com.example.contractservice.common.util.StringUtil;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.hexagon.core.dto.Empty;
+import org.hexagon.core.dto.ResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
@@ -11,19 +13,19 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.hexagon.core.dto.ResponseDto;
-import org.hexagon.core.dto.Empty;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ResponseDto<Empty> handle(MethodArgumentNotValidException e) {
-        String allExceptionMessages = e.getBindingResult().getAllErrors().stream().map(err -> err.getDefaultMessage())
+        String allExceptionMessages = e.getBindingResult().getAllErrors().stream()
+                .map(err -> err.getDefaultMessage())
                 .collect(Collectors.joining(" | "));
 
-        String message = StringUtil.format("?낅젰 媛믪씠 ?щ컮瑜댁? ?딆뒿?덈떎. {}", allExceptionMessages);
+        String message = StringUtil.format("입력 값이 올바르지 않습니다. {}", allExceptionMessages);
 
         return new ResponseDto<>(4999, HttpStatus.BAD_REQUEST.value(), message, Empty.getInstance());
     }
@@ -31,10 +33,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BindException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ResponseDto<Empty> handle(BindException e) {
-        String bindingFailObjects = e.getBindingResult().getAllErrors().stream().map(ObjectError::getObjectName)
+        String bindingFailObjects = e.getBindingResult().getAllErrors().stream()
+                .map(ObjectError::getObjectName)
                 .collect(Collectors.joining(", "));
 
-        String message = StringUtil.format("?섎せ????낆쓽 ?낅젰??議댁옱?⑸땲?? ?ㅼ쓬???뺤씤?섏떗?쒖삤: {}", bindingFailObjects);
+        String message = StringUtil.format("잘못된 타입의 입력이 존재합니다. 다음을 확인하십시오: {}", bindingFailObjects);
 
         return new ResponseDto<>(4999, HttpStatus.BAD_REQUEST.value(), message, Empty.getInstance());
     }
@@ -42,7 +45,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HttpMessageNotReadableException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ResponseDto<Empty> handle() {
-        String message = "?섎せ????낆쓽 ?낅젰???덇굅???낅젰 援ъ“媛 ?섎せ?섏뿀?듬땲??";
+        String message = "잘못된 타입의 입력이 있거나 입력 구조가 잘못되었습니다.";
 
         return new ResponseDto<>(4999, HttpStatus.BAD_REQUEST.value(), message, Empty.getInstance());
     }
@@ -50,7 +53,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ResponseDto<Empty> handle(Exception e) {
-        log.error("?????녿뒗 ?덉쇅 諛쒖깮. 鍮좊Ⅸ ?뺤씤 ?꾩슂!", e);
+        log.error("알 수 없는 예외 발생. 빠른 확인 필요!", e);
 
         return ResponseDto.fail();
     }

--- a/contract-service/src/main/java/com/example/contractservice/common/domain/exception/DomainException.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/domain/exception/DomainException.java
@@ -4,6 +4,7 @@ public class DomainException extends RuntimeException {
     protected final DomainErrorCode errorCode;
 
     public DomainException(DomainErrorCode errorCode) {
+        super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
 

--- a/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/request/ContractPayRequest.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/controller/dto/request/ContractPayRequest.java
@@ -10,9 +10,8 @@ public record ContractPayRequest(
                 message = "유효한 UUID 형식이어야 합니다.")
         String xCode,
         @Schema(description = "결제할 계약 코드", example = "a94472b1-be7d-4c5b-8342-94b5a175be9d")
-        @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-                message = "유효한 UUID 형식이어야 합니다.")
-        List<String> codes
+        List<@Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                message = "유효한 UUID 형식이어야 합니다.") String> codes
 ) {
 
 }

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/ContractCancelService.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/ContractCancelService.java
@@ -8,12 +8,12 @@ import com.example.contractservice.contract.domain.exception.ContractException;
 import com.example.contractservice.contract.repository.ContractRepository;
 import com.example.contractservice.contract.service.mapper.ContractMapper;
 import com.example.contractservice.deposit.controller.dto.response.DepositHistoryInfo;
+import com.example.contractservice.deposit.service.DepositPendingService;
 import com.example.contractservice.deposit.service.DepositService;
 import com.example.contractservice.deposit.service.dto.request.DepositProcessRequest;
 import com.example.contractservice.settlement.service.SettlementService;
 import lombok.RequiredArgsConstructor;
 import org.hexagon.core.events.contract.CommissionOpenCloseEvent;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,14 +22,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ContractCancelService {
 
+    private static final String REFUND_COMMENT = "환불 처리";
+
     private final DepositService depositService;
+    private final DepositPendingService depositPendingService;
     private final SettlementService settlementService;
     private final ContractRepository contractRepository;
     private final CommissionsCapacityService commissionsCapacityService;
     private final ApplicationEventPublisher applicationEventPublisher;
-
-    @Value("${admin.member.code}")
-    private String adminMemberCode;
 
     @Transactional
     public void processCancel(Contract contract) {
@@ -50,9 +50,18 @@ public class ContractCancelService {
     }
 
     private void rollbackPaidContract(Contract contract) {
-        publishEventIfCommissionFull(contract); // 의뢰글 마감 상태였다면 의뢰글 오픈 이벤트 발행
-        refund(contract); // 환불
-        deleteCancelableSettlements(contract); // 정산 데이터 제거
+        cancelPending(contract);
+        publishEventIfCommissionFull(contract);
+        refund(contract);
+        deleteCancelableSettlements(contract);
+    }
+
+    private void cancelPending(Contract contract) {
+        boolean isCancelled = depositPendingService.cancelPendingByContractCode(contract.getCode());
+
+        if (!isCancelled) {
+            throw new ContractException(CANCEL_NOT_AVAILABLE);
+        }
     }
 
     private void publishEventIfCommissionFull(Contract contract) {
@@ -64,20 +73,20 @@ public class ContractCancelService {
         }
     }
 
-    /** 관리자 예치금 withdraw 이후 해당 유저 예치금으로 transfer
+    /** 결제한 유저 예치금으로 transfer
      *
      * @param contract 환불을 진행할 계약
      */
     private void refund(Contract contract) {
         DepositHistoryInfo historyInfo = depositService.getDepositHistoryForRefund(
                 contract.getInfo().clientCode(), contract.getCode());
-        DepositProcessRequest adminWithdrawRequest = new DepositProcessRequest(adminMemberCode, contract.getCode(),
-                Math.abs(historyInfo.changeAmount()), "환불 처리");
+        DepositProcessRequest memberTransferRequest = new DepositProcessRequest(
+                contract.getInfo().clientCode(),
+                contract.getCode(),
+                Math.abs(historyInfo.changeAmount()),
+                REFUND_COMMENT
+        );
 
-        depositService.withdraw(adminWithdrawRequest);
-
-        DepositProcessRequest memberTransferRequest = new DepositProcessRequest(contract.getInfo().clientCode(), contract.getCode(),
-                Math.abs(historyInfo.changeAmount()), "환불 처리");
         depositService.transfer(memberTransferRequest);
     }
 

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/ContractCancelService.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/ContractCancelService.java
@@ -52,7 +52,7 @@ public class ContractCancelService {
     private void rollbackPaidContract(Contract contract) {
         publishEventIfCommissionFull(contract); // 의뢰글 마감 상태였다면 의뢰글 오픈 이벤트 발행
         refund(contract); // 환불
-        removeSettlements(contract); // 정산 데이터 제거
+        deleteCancelableSettlements(contract); // 정산 데이터 제거
     }
 
     private void publishEventIfCommissionFull(Contract contract) {
@@ -81,12 +81,7 @@ public class ContractCancelService {
         depositService.transfer(memberTransferRequest);
     }
 
-    /** 해당 계약과 관련된 모든 정산 데이터를 하드 딜리트합니다.
-     *
-     * @param contract 정산 데이터를 지울 관련 계약
-     */
-    private void removeSettlements(Contract contract) {
-        settlementService.deleteAllRelatedWith(contract);
+    private void deleteCancelableSettlements(Contract contract) {
+        settlementService.deleteCancelableSettlements(contract);
     }
-
 }

--- a/contract-service/src/main/java/com/example/contractservice/contract/service/ContractPayService.java
+++ b/contract-service/src/main/java/com/example/contractservice/contract/service/ContractPayService.java
@@ -13,7 +13,9 @@ import com.example.contractservice.contract.repository.ContractRepository;
 import com.example.contractservice.contract.service.dto.request.ContractPayProcessRequest;
 import com.example.contractservice.contract.service.mapper.ContractMapper;
 import com.example.contractservice.contract.service.mapper.ContractSettlementMapper;
+import com.example.contractservice.deposit.service.DepositPendingService;
 import com.example.contractservice.deposit.service.DepositService;
+import com.example.contractservice.deposit.service.dto.request.DepositPendingSaveRequest;
 import com.example.contractservice.deposit.service.dto.request.DepositProcessRequest;
 import com.example.contractservice.settlement.service.SettlementService;
 import java.time.Duration;
@@ -21,7 +23,6 @@ import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hexagon.core.events.contract.CommissionOpenCloseEvent;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,13 +34,11 @@ public class ContractPayService {
     private static final String PAYMENT_COMMENT = "계약 결제";
 
     private final DepositService depositService;
+    private final DepositPendingService depositPendingService;
     private final SettlementService settlementService;
     private final ContractRepository contractRepository;
     private final CommissionsCapacityRepository commissionsCapacityRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
-
-    @Value("${admin.member.code}")
-    private String adminMemberCode;
 
     @Transactional
     @OptimisticRetry
@@ -130,8 +129,7 @@ public class ContractPayService {
         DepositProcessRequest depositProcessRequest = new DepositProcessRequest(xCode, contract.getCode(), totalAmount, PAYMENT_COMMENT);
         depositService.withdraw(depositProcessRequest);
 
-        DepositProcessRequest adminDepositProcessRequest = new DepositProcessRequest(adminMemberCode, contract.getCode(), totalAmount, "계약 결제 금액 수금");
-        depositService.transfer(adminDepositProcessRequest); // 관리자 예치금으로 입금
+        depositPendingService.save(new DepositPendingSaveRequest(totalAmount, contract.getCode()));
     }
 
     private void saveSettlements(Contract contract) {

--- a/contract-service/src/main/java/com/example/contractservice/deposit/common/DepositPendingStatus.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/common/DepositPendingStatus.java
@@ -1,12 +1,14 @@
 package com.example.contractservice.deposit.common;
 
 /**
- * PENDING: 계약 결제가 완료되어 관리자 예치금에 반영되기 이전
- * COMPLETED: 관리자 예치금에 반영된 건
- * CANCELLED: 취소된 계약
+ * PENDING: 계약 결제 완료 이후 관리자 예치금에 반영되기 이전
+ * COMPLETED: 관리자 예치금에 반영
+ * CANCELLED: 관리자 예치금 반영 전, 계약 취소
+ * FAILED: 관리자 예치금 반영 처리 실패
  */
 public enum DepositPendingStatus {
     PENDING,
     COMPLETED,
+    FAILED,
     CANCELLED
 }

--- a/contract-service/src/main/java/com/example/contractservice/deposit/common/DepositPendingStatus.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/common/DepositPendingStatus.java
@@ -1,0 +1,12 @@
+package com.example.contractservice.deposit.common;
+
+/**
+ * PENDING: 계약 결제가 완료되어 관리자 예치금에 반영되기 이전
+ * COMPLETED: 관리자 예치금에 반영된 건
+ * CANCELLED: 취소된 계약
+ */
+public enum DepositPendingStatus {
+    PENDING,
+    COMPLETED,
+    CANCELLED
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/domain/DepositPending.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/domain/DepositPending.java
@@ -1,24 +1,50 @@
 package com.example.contractservice.deposit.domain;
 
+import static com.example.contractservice.deposit.domain.exception.DepositErrorCode.INVALID_PENDING_STATUS;
+
+import com.example.contractservice.deposit.common.DepositPendingStatus;
+import com.example.contractservice.deposit.domain.exception.DepositException;
 import com.example.contractservice.deposit.domain.vo.DepositPendingDetails;
 import java.time.Instant;
 
 public class DepositPending {
-    private Long id;
-    private String contractCode;
+    private final Long id;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+    private final String contractCode;
+    private final DepositPendingDetails depositPendingDetails;
 
-    private DepositPendingDetails depositPendingDetails;
-
-    private Instant createdAt;
-    private Instant updatedAt;
-
-    public DepositPending(String contractCode, DepositPendingDetails depositPendingDetails) {
+    public DepositPending(Long id, Instant createdAt, Instant updatedAt, String contractCode,
+            DepositPendingDetails depositPendingDetails) {
+        this.id = id;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
         this.contractCode = contractCode;
         this.depositPendingDetails = depositPendingDetails;
     }
 
-    public void markCompleted() {
-        this.depositPendingDetails = depositPendingDetails.completed();
+    public DepositPending(Long id, String contractCode, DepositPendingDetails depositPendingDetails) {
+        this(id, null, null, contractCode, depositPendingDetails);
+    }
+
+    public DepositPending(String contractCode, DepositPendingDetails depositPendingDetails) {
+        this(null, contractCode, depositPendingDetails);
+    }
+
+    public boolean isInvalidAmount() {
+        return depositPendingDetails.isInvalidAmount();
+    }
+
+    public boolean hasPositiveAmount() {
+        return depositPendingDetails.hasPositiveAmount();
+    }
+
+    public DepositPending complete(Instant processedAt) {
+        return new DepositPending(id, createdAt, processedAt, contractCode, depositPendingDetails.complete(processedAt));
+    }
+
+    public DepositPending fail(Instant processedAt) {
+        return new DepositPending(id, createdAt, processedAt, contractCode, depositPendingDetails.fail(processedAt));
     }
 
     // getter
@@ -30,10 +56,6 @@ public class DepositPending {
         return contractCode;
     }
 
-    public DepositPendingDetails getDepositPendingDetails() {
-        return depositPendingDetails;
-    }
-
     public Instant getCreatedAt() {
         return createdAt;
     }
@@ -41,4 +63,21 @@ public class DepositPending {
     public Instant getUpdatedAt() {
         return updatedAt;
     }
+
+    public DepositPendingDetails getDepositPendingDetails() {
+        return depositPendingDetails;
+    }
+
+    public Long getAmount() {
+        return depositPendingDetails.getAmount();
+    }
+
+    public DepositPendingStatus getStatus() {
+        return depositPendingDetails.getStatus();
+    }
+
+    public Instant getProcessedAt() {
+        return depositPendingDetails.getProcessedAt();
+    }
+
 }

--- a/contract-service/src/main/java/com/example/contractservice/deposit/domain/DepositPending.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/domain/DepositPending.java
@@ -10,11 +10,11 @@ public class DepositPending {
     private DepositPendingDetails depositPendingDetails;
 
     private Instant createdAt;
+    private Instant updatedAt;
 
-    public DepositPending(String contractCode, DepositPendingDetails depositPendingDetails, Instant createdAt) {
+    public DepositPending(String contractCode, DepositPendingDetails depositPendingDetails) {
         this.contractCode = contractCode;
         this.depositPendingDetails = depositPendingDetails;
-        this.createdAt = createdAt;
     }
 
     public void markCompleted() {
@@ -36,5 +36,9 @@ public class DepositPending {
 
     public Instant getCreatedAt() {
         return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
     }
 }

--- a/contract-service/src/main/java/com/example/contractservice/deposit/domain/DepositPending.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/domain/DepositPending.java
@@ -1,0 +1,40 @@
+package com.example.contractservice.deposit.domain;
+
+import com.example.contractservice.deposit.domain.vo.DepositPendingDetails;
+import java.time.Instant;
+
+public class DepositPending {
+    private Long id;
+    private String contractCode;
+
+    private DepositPendingDetails depositPendingDetails;
+
+    private Instant createdAt;
+
+    public DepositPending(String contractCode, DepositPendingDetails depositPendingDetails, Instant createdAt) {
+        this.contractCode = contractCode;
+        this.depositPendingDetails = depositPendingDetails;
+        this.createdAt = createdAt;
+    }
+
+    public void markCompleted() {
+        this.depositPendingDetails = depositPendingDetails.completed();
+    }
+
+    // getter
+    public Long getId() {
+        return id;
+    }
+
+    public String getContractCode() {
+        return contractCode;
+    }
+
+    public DepositPendingDetails getDepositPendingDetails() {
+        return depositPendingDetails;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/domain/exception/DepositErrorCode.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/domain/exception/DepositErrorCode.java
@@ -7,29 +7,24 @@ public class DepositErrorCode extends DomainErrorCode {
     public static final DepositErrorCode NO_DEPOSIT_ENTITY;
     public static final DepositErrorCode NOT_ENOUGH_AMOUNT;
     public static final DepositErrorCode INVALID_AMOUNT;
-
+    public static final DepositErrorCode INVALID_PENDING_STATUS;
     public static final DepositErrorCode ALREADY_EXISTS;
-
     public static final DepositErrorCode NO_HISTORY_ENTITY;
     public static final DepositErrorCode DEPOSIT_BATCH_UPDATE_FAILED;
-
-    public static final DepositErrorCode INVALID_STATUS_FOR_COMPLETED;
+    public static final DepositErrorCode DEPOSIT_PENDING_BATCH_UPDATE_FAILED;
 
     static {
-        NO_DEPOSIT_ENTITY = new DepositErrorCode(HttpStatus.BAD_REQUEST, 4100, "해당하는 예치금이 존재하지 않습니다.");
-        NOT_ENOUGH_AMOUNT = new DepositErrorCode(HttpStatus.BAD_REQUEST, 4101, "예치금 잔액이 부족합니다.");
-        INVALID_AMOUNT = new DepositErrorCode(HttpStatus.BAD_REQUEST, 4102, "처리 금액이 잘못되었습니다.");
-
+        NO_DEPOSIT_ENTITY = new DepositErrorCode(HttpStatus.BAD_REQUEST, 4100, "해당 예치금이 존재하지 않습니다.");
+        NOT_ENOUGH_AMOUNT = new DepositErrorCode(HttpStatus.BAD_REQUEST, 4101, "예치금의 금액이 부족합니다.");
+        INVALID_AMOUNT = new DepositErrorCode(HttpStatus.BAD_REQUEST, 4102, "처리 금액이 올바르지 않습니다.");
+        INVALID_PENDING_STATUS = new DepositErrorCode(HttpStatus.BAD_REQUEST, 4103, "deposit pending 상태 전이가 올바르지 않습니다.");
         ALREADY_EXISTS = new DepositErrorCode(HttpStatus.BAD_REQUEST, 4110, "이미 존재하는 예치금입니다.");
-
-        NO_HISTORY_ENTITY = new DepositErrorCode(HttpStatus.BAD_REQUEST, 4120, "해당하는 예치금 내역이 존재하지 않습니다.");
-
-        DEPOSIT_BATCH_UPDATE_FAILED = new DepositErrorCode(HttpStatus.INTERNAL_SERVER_ERROR, 4130, "예치금 배치 업데이트 중에 업데이트 되지 않은 데이터가 존재합니다.");
-
-        INVALID_STATUS_FOR_COMPLETED = new DepositErrorCode(HttpStatus.BAD_REQUEST, 4140, "관리자 예치금 배치 정산을 위해서는 PENDING 상태여야만 합니다.");
+        NO_HISTORY_ENTITY = new DepositErrorCode(HttpStatus.BAD_REQUEST, 4120, "해당 예치금 내역이 존재하지 않습니다.");
+        DEPOSIT_BATCH_UPDATE_FAILED = new DepositErrorCode(HttpStatus.INTERNAL_SERVER_ERROR, 4130, "예치금 배치 업데이트 중 갱신되지 않은 데이터가 존재합니다.");
+        DEPOSIT_PENDING_BATCH_UPDATE_FAILED = new DepositErrorCode(HttpStatus.INTERNAL_SERVER_ERROR, 4131, "deposit pending 배치 업데이트 중 갱신되지 않은 데이터가 존재합니다.");
     }
 
-   private DepositErrorCode(HttpStatus httpStatusCode, int statusCode, String message) {
+    private DepositErrorCode(HttpStatus httpStatusCode, int statusCode, String message) {
         super(httpStatusCode, statusCode, message);
     }
 }

--- a/contract-service/src/main/java/com/example/contractservice/deposit/domain/exception/DepositErrorCode.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/domain/exception/DepositErrorCode.java
@@ -13,6 +13,8 @@ public class DepositErrorCode extends DomainErrorCode {
     public static final DepositErrorCode NO_HISTORY_ENTITY;
     public static final DepositErrorCode DEPOSIT_BATCH_UPDATE_FAILED;
 
+    public static final DepositErrorCode INVALID_STATUS_FOR_COMPLETED;
+
     static {
         NO_DEPOSIT_ENTITY = new DepositErrorCode(HttpStatus.BAD_REQUEST, 4100, "해당하는 예치금이 존재하지 않습니다.");
         NOT_ENOUGH_AMOUNT = new DepositErrorCode(HttpStatus.BAD_REQUEST, 4101, "예치금 잔액이 부족합니다.");
@@ -24,6 +26,7 @@ public class DepositErrorCode extends DomainErrorCode {
 
         DEPOSIT_BATCH_UPDATE_FAILED = new DepositErrorCode(HttpStatus.INTERNAL_SERVER_ERROR, 4130, "예치금 배치 업데이트 중에 업데이트 되지 않은 데이터가 존재합니다.");
 
+        INVALID_STATUS_FOR_COMPLETED = new DepositErrorCode(HttpStatus.BAD_REQUEST, 4140, "관리자 예치금 배치 정산을 위해서는 PENDING 상태여야만 합니다.");
     }
 
    private DepositErrorCode(HttpStatus httpStatusCode, int statusCode, String message) {

--- a/contract-service/src/main/java/com/example/contractservice/deposit/domain/vo/DepositPendingDetails.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/domain/vo/DepositPendingDetails.java
@@ -12,9 +12,8 @@ public class DepositPendingDetails {
     private DepositPendingStatus status;
     private Instant processedAt;
 
-    public DepositPendingDetails(Long amount, Instant processedAt) {
+    public DepositPendingDetails(Long amount) {
         this.amount = amount;
-        this.processedAt = processedAt;
         this.status = DepositPendingStatus.PENDING;
     }
 

--- a/contract-service/src/main/java/com/example/contractservice/deposit/domain/vo/DepositPendingDetails.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/domain/vo/DepositPendingDetails.java
@@ -1,0 +1,46 @@
+package com.example.contractservice.deposit.domain.vo;
+
+import static com.example.contractservice.deposit.domain.exception.DepositErrorCode.INVALID_STATUS_FOR_COMPLETED;
+
+import com.example.contractservice.deposit.common.DepositPendingStatus;
+import com.example.contractservice.deposit.domain.exception.DepositException;
+import java.time.Instant;
+
+public class DepositPendingDetails {
+
+    private Long amount;
+    private DepositPendingStatus status;
+    private Instant processedAt;
+
+    public DepositPendingDetails(Long amount, Instant processedAt) {
+        this.amount = amount;
+        this.processedAt = processedAt;
+        this.status = DepositPendingStatus.PENDING;
+    }
+
+    private DepositPendingDetails(Long amount, DepositPendingStatus status, Instant processedAt) {
+        this.amount = amount;
+        this.status = status;
+        this.processedAt = processedAt;
+    }
+
+    public DepositPendingDetails completed() {
+        if (this.status != DepositPendingStatus.PENDING) {
+            throw new DepositException(INVALID_STATUS_FOR_COMPLETED);
+        }
+
+        return new DepositPendingDetails(this.amount, DepositPendingStatus.COMPLETED, Instant.now());
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public DepositPendingStatus getStatus() {
+        return status;
+    }
+
+    public Instant getProcessedAt() {
+        return processedAt;
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/domain/vo/DepositPendingDetails.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/domain/vo/DepositPendingDetails.java
@@ -1,6 +1,6 @@
 package com.example.contractservice.deposit.domain.vo;
 
-import static com.example.contractservice.deposit.domain.exception.DepositErrorCode.INVALID_STATUS_FOR_COMPLETED;
+import static com.example.contractservice.deposit.domain.exception.DepositErrorCode.INVALID_PENDING_STATUS;
 
 import com.example.contractservice.deposit.common.DepositPendingStatus;
 import com.example.contractservice.deposit.domain.exception.DepositException;
@@ -8,27 +8,18 @@ import java.time.Instant;
 
 public class DepositPendingDetails {
 
-    private Long amount;
-    private DepositPendingStatus status;
-    private Instant processedAt;
+    private final Long amount;
+    private final DepositPendingStatus status;
+    private final Instant processedAt;
 
-    public DepositPendingDetails(Long amount) {
-        this.amount = amount;
-        this.status = DepositPendingStatus.PENDING;
-    }
-
-    private DepositPendingDetails(Long amount, DepositPendingStatus status, Instant processedAt) {
+    public DepositPendingDetails(Long amount, DepositPendingStatus status, Instant processedAt) {
         this.amount = amount;
         this.status = status;
         this.processedAt = processedAt;
     }
 
-    public DepositPendingDetails completed() {
-        if (this.status != DepositPendingStatus.PENDING) {
-            throw new DepositException(INVALID_STATUS_FOR_COMPLETED);
-        }
-
-        return new DepositPendingDetails(this.amount, DepositPendingStatus.COMPLETED, Instant.now());
+    public DepositPendingDetails(Long amount) {
+        this(amount, DepositPendingStatus.PENDING, null);
     }
 
     public Long getAmount() {
@@ -41,5 +32,29 @@ public class DepositPendingDetails {
 
     public Instant getProcessedAt() {
         return processedAt;
+    }
+
+    public DepositPendingDetails complete(Instant processedAt) {
+        validatePendingStatus();
+        return new DepositPendingDetails(amount, DepositPendingStatus.COMPLETED, processedAt);
+    }
+
+    public DepositPendingDetails fail(Instant processedAt) {
+        validatePendingStatus();
+        return new DepositPendingDetails(amount, DepositPendingStatus.FAILED, processedAt);
+    }
+
+    public boolean isInvalidAmount() {
+        return amount == null || amount < 0L;
+    }
+
+    public boolean hasPositiveAmount() {
+        return amount != null && amount > 0L;
+    }
+
+    private void validatePendingStatus() {
+        if (status != DepositPendingStatus.PENDING) {
+            throw new DepositException(INVALID_PENDING_STATUS);
+        }
     }
 }

--- a/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositPendingEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositPendingEntity.java
@@ -1,14 +1,15 @@
 package com.example.contractservice.deposit.entity;
 
-import com.example.contractservice.common.entity.BaseEntity;
 import com.example.contractservice.deposit.common.DepositPendingStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -19,17 +20,15 @@ import lombok.NoArgsConstructor;
 @Table(
         name = "deposit_pendings",
         indexes = {
-                @Index(name = "idx_deposit_pending_status_created_at", columnList = "status, processed_at")
-        },
-        uniqueConstraints = {
-                @UniqueConstraint(name = "uk_deposit_pending_code", columnNames = "code")
+                @Index(name = "idx_status_created_at", columnList = "status, created_at")
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class DepositPendingEntity extends BaseEntity {
+public class DepositPendingEntity {
 
-    @Column(name = "member_code", nullable = false, columnDefinition = "CHAR(36)")
-    private String memberCode;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     @Column(name = "contract_code", nullable = false, columnDefinition = "CHAR(36)")
     private String contractCode;
@@ -41,18 +40,13 @@ public class DepositPendingEntity extends BaseEntity {
     @Column(name = "status", nullable = false, length = 20)
     private DepositPendingStatus status;
 
-    @Column(name = "processed_at")
+    @Column(name = "processed_at", columnDefinition = "datetime(6)")
     private Instant processedAt;
 
-    private DepositPendingEntity(String memberCode, String contractCode, Long amount) {
-        this.memberCode = memberCode;
+    private DepositPendingEntity(String contractCode, Long amount) {
         this.contractCode = contractCode;
         this.amount = amount;
         this.status = DepositPendingStatus.PENDING;
-    }
-
-    public static DepositPendingEntity create(String memberCode, String contractCode, Long amount) {
-        return new DepositPendingEntity(memberCode, contractCode, amount);
     }
 
     public void markCompleted() {

--- a/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositPendingEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositPendingEntity.java
@@ -15,6 +15,7 @@ import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 
 @Entity
 @Getter
@@ -30,6 +31,10 @@ public class DepositPendingEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, columnDefinition = "datetime(6)")
+    private Instant createdAt;
 
     @Column(name = "contract_code", nullable = false, columnDefinition = "CHAR(36)")
     private String contractCode;

--- a/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositPendingEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositPendingEntity.java
@@ -1,0 +1,63 @@
+package com.example.contractservice.deposit.entity;
+
+import com.example.contractservice.common.entity.BaseEntity;
+import com.example.contractservice.deposit.common.DepositPendingStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(
+        name = "deposit_pendings",
+        indexes = {
+                @Index(name = "idx_deposit_pending_status_created_at", columnList = "status, processed_at")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_deposit_pending_code", columnNames = "code")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DepositPendingEntity extends BaseEntity {
+
+    @Column(name = "member_code", nullable = false, columnDefinition = "CHAR(36)")
+    private String memberCode;
+
+    @Column(name = "contract_code", nullable = false, columnDefinition = "CHAR(36)")
+    private String contractCode;
+
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private DepositPendingStatus status;
+
+    @Column(name = "processed_at")
+    private Instant processedAt;
+
+    private DepositPendingEntity(String memberCode, String contractCode, Long amount) {
+        this.memberCode = memberCode;
+        this.contractCode = contractCode;
+        this.amount = amount;
+        this.status = DepositPendingStatus.PENDING;
+    }
+
+    public static DepositPendingEntity create(String memberCode, String contractCode, Long amount) {
+        return new DepositPendingEntity(memberCode, contractCode, amount);
+    }
+
+    public void markCompleted() {
+        this.status = DepositPendingStatus.COMPLETED;
+        this.processedAt = Instant.now();
+    }
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositPendingEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositPendingEntity.java
@@ -4,6 +4,7 @@ import com.example.contractservice.deposit.common.DepositPendingStatus;
 import com.example.contractservice.deposit.domain.DepositPending;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -17,6 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
@@ -27,6 +29,7 @@ import org.springframework.data.annotation.LastModifiedDate;
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class DepositPendingEntity {
 
     @Id

--- a/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositPendingEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositPendingEntity.java
@@ -1,7 +1,6 @@
 package com.example.contractservice.deposit.entity;
 
 import com.example.contractservice.deposit.common.DepositPendingStatus;
-import com.example.contractservice.deposit.domain.DepositPending;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -63,11 +62,7 @@ public class DepositPendingEntity {
         this.status = DepositPendingStatus.PENDING;
     }
 
-    public static DepositPendingEntity toEntity(DepositPending depositPending) {
-        return new DepositPendingEntity(
-                depositPending.getContractCode(),
-                depositPending.getDepositPendingDetails().getAmount()
-        );
+    public static DepositPendingEntity create(String contractCode, Long amount) {
+        return new DepositPendingEntity(contractCode, amount);
     }
-
 }

--- a/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositPendingEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositPendingEntity.java
@@ -16,6 +16,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
 @Entity
 @Getter
@@ -35,6 +36,10 @@ public class DepositPendingEntity {
     @CreatedDate
     @Column(name = "created_at", nullable = false, columnDefinition = "datetime(6)")
     private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false, columnDefinition = "datetime(6)")
+    private Instant updatedAt;
 
     @Column(name = "contract_code", nullable = false, columnDefinition = "CHAR(36)")
     private String contractCode;

--- a/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositPendingEntity.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/entity/DepositPendingEntity.java
@@ -1,6 +1,7 @@
 package com.example.contractservice.deposit.entity;
 
 import com.example.contractservice.deposit.common.DepositPendingStatus;
+import com.example.contractservice.deposit.domain.DepositPending;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -49,9 +50,11 @@ public class DepositPendingEntity {
         this.status = DepositPendingStatus.PENDING;
     }
 
-    public void markCompleted() {
-        this.status = DepositPendingStatus.COMPLETED;
-        this.processedAt = Instant.now();
+    public static DepositPendingEntity toEntity(DepositPending depositPending) {
+        return new DepositPendingEntity(
+                depositPending.getContractCode(),
+                depositPending.getDepositPendingDetails().getAmount()
+        );
     }
 
 }

--- a/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositJpaRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositJpaRepository.java
@@ -1,12 +1,23 @@
 package com.example.contractservice.deposit.repository;
 
 import com.example.contractservice.deposit.entity.DepositEntity;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface DepositJpaRepository extends JpaRepository<DepositEntity, Long> {
 
     Optional<DepositEntity> findByMemberCode(String memberCode);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT d
+        FROM DepositEntity d
+        WHERE d.memberCode = :memberCode
+    """)
+    Optional<DepositEntity> findByMemberCodeForUpdate(String memberCode);
 
     boolean existsByMemberCode(String memberCode);
 }

--- a/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositPendingJpaRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositPendingJpaRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DepositPendingJpaRepository extends JpaRepository<DepositPendingEntity, Long> {
 
@@ -23,9 +24,30 @@ public interface DepositPendingJpaRepository extends JpaRepository<DepositPendin
     @Query(value = """
         SELECT *
         FROM deposit_pendings dp
-        WHERE dp.status = :status AND dp.processedAt <= :endTime
-        ORDER BY dp.status, dp.processedAt
+        WHERE dp.status = :status
+          AND dp.created_at < :cutoff
+        ORDER BY dp.status, dp.created_at
         LIMIT :limit
+        FOR UPDATE SKIP LOCKED
     """, nativeQuery = true)
-    List<DepositPendingEntity> findAllByStatusOrderByProcessedAt(String status, Instant endTime, int limit);
+    List<DepositPendingEntity> findPendingBeforeWithLock(
+            @Param("status") String status,
+            @Param("cutoff") Instant cutoff,
+            @Param("limit") int limit
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE DepositPendingEntity dp
+        SET dp.status = :status,
+            dp.processedAt = :processedAt,
+            dp.updatedAt = :processedAt
+        WHERE dp.id IN :ids
+    """)
+    int updateStatusByIds(
+            @Param("ids") List<Long> ids,
+            @Param("status") DepositPendingStatus status,
+            @Param("processedAt") Instant processedAt
+    );
+
 }

--- a/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositPendingJpaRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositPendingJpaRepository.java
@@ -1,12 +1,24 @@
 package com.example.contractservice.deposit.repository;
 
+import com.example.contractservice.deposit.common.DepositPendingStatus;
 import com.example.contractservice.deposit.entity.DepositPendingEntity;
 import java.time.Instant;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface DepositPendingJpaRepository extends JpaRepository<DepositPendingEntity, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE DepositPendingEntity dp
+        SET dp.status = :nextStatus,
+            dp.updatedAt = CURRENT_TIMESTAMP
+        WHERE dp.contractCode = :contractCode
+          AND dp.status = :currentStatus
+    """)
+    int updateStatusByContractCode(String contractCode, DepositPendingStatus currentStatus, DepositPendingStatus nextStatus);
 
     @Query(value = """
         SELECT *

--- a/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositPendingJpaRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositPendingJpaRepository.java
@@ -1,0 +1,19 @@
+package com.example.contractservice.deposit.repository;
+
+import com.example.contractservice.deposit.entity.DepositPendingEntity;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface DepositPendingJpaRepository extends JpaRepository<DepositPendingEntity, Long> {
+
+    @Query(value = """
+        SELECT *
+        FROM deposit_pendings dp
+        WHERE dp.status = :status AND dp.processedAt <= :endTime
+        ORDER BY dp.status, dp.processedAt
+        LIMIT :limit
+    """, nativeQuery = true)
+    List<DepositPendingEntity> findAllByStatusOrderByProcessedAt(String status, Instant endTime, int limit);
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositPendingRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositPendingRepository.java
@@ -3,6 +3,11 @@ package com.example.contractservice.deposit.repository;
 import com.example.contractservice.deposit.common.DepositPendingStatus;
 import com.example.contractservice.deposit.domain.DepositPending;
 import com.example.contractservice.deposit.entity.DepositPendingEntity;
+import com.example.contractservice.deposit.domain.exception.DepositErrorCode;
+import com.example.contractservice.deposit.domain.exception.DepositException;
+import com.example.contractservice.deposit.service.mapper.DepositPendingMapper;
+import java.time.Instant;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -12,7 +17,7 @@ public class DepositPendingRepository {
     private final DepositPendingJpaRepository depositPendingJpaRepository;
 
     public void save(DepositPending depositPending) {
-        DepositPendingEntity entity = DepositPendingEntity.toEntity(depositPending);
+        DepositPendingEntity entity = DepositPendingMapper.toEntity(depositPending);
         depositPendingJpaRepository.save(entity);
     }
 
@@ -24,6 +29,32 @@ public class DepositPendingRepository {
         );
 
         return updatedRows > 0;
+    }
+
+    public List<DepositPending> findPendingBeforeWithLock(Instant cutoff, int limit) {
+        return depositPendingJpaRepository.findPendingBeforeWithLock(DepositPendingStatus.PENDING.name(), cutoff, limit)
+                .stream()
+                .map(DepositPendingMapper::toDomain)
+                .toList();
+    }
+
+    public void markCompletedByIds(List<Long> ids, Instant processedAt) {
+        updateStatusByIds(ids, DepositPendingStatus.COMPLETED, processedAt);
+    }
+
+    public void markFailedByIds(List<Long> ids, Instant processedAt) {
+        updateStatusByIds(ids, DepositPendingStatus.FAILED, processedAt);
+    }
+
+    private void updateStatusByIds(List<Long> ids, DepositPendingStatus status, Instant processedAt) {
+        if (ids.isEmpty()) {
+            return;
+        }
+
+        int updatedRows = depositPendingJpaRepository.updateStatusByIds(ids, status, processedAt);
+        if (updatedRows != ids.size()) {
+            throw new DepositException(DepositErrorCode.DEPOSIT_PENDING_BATCH_UPDATE_FAILED);
+        }
     }
 
 }

--- a/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositPendingRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositPendingRepository.java
@@ -1,5 +1,6 @@
 package com.example.contractservice.deposit.repository;
 
+import com.example.contractservice.deposit.common.DepositPendingStatus;
 import com.example.contractservice.deposit.domain.DepositPending;
 import com.example.contractservice.deposit.entity.DepositPendingEntity;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,16 @@ public class DepositPendingRepository {
     public void save(DepositPending depositPending) {
         DepositPendingEntity entity = DepositPendingEntity.toEntity(depositPending);
         depositPendingJpaRepository.save(entity);
+    }
+
+    public boolean cancelPendingByContractCode(String contractCode) {
+        int updatedRows = depositPendingJpaRepository.updateStatusByContractCode(
+                contractCode,
+                DepositPendingStatus.PENDING,
+                DepositPendingStatus.CANCELLED
+        );
+
+        return updatedRows > 0;
     }
 
 }

--- a/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositPendingRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositPendingRepository.java
@@ -1,0 +1,18 @@
+package com.example.contractservice.deposit.repository;
+
+import com.example.contractservice.deposit.domain.DepositPending;
+import com.example.contractservice.deposit.entity.DepositPendingEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DepositPendingRepository {
+    private final DepositPendingJpaRepository depositPendingJpaRepository;
+
+    public void save(DepositPending depositPending) {
+        DepositPendingEntity entity = DepositPendingEntity.toEntity(depositPending);
+        depositPendingJpaRepository.save(entity);
+    }
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/repository/DepositRepository.java
@@ -31,6 +31,11 @@ public class DepositRepository {
                 .orElseThrow(() -> new DepositException(NO_DEPOSIT_ENTITY)));
     }
 
+    public Deposit findDepositByMemberCodeForUpdate(String memberCode) {
+        return DepositMapper.toDomain(depositJpaRepository.findByMemberCodeForUpdate(memberCode)
+                .orElseThrow(() -> new DepositException(NO_DEPOSIT_ENTITY)));
+    }
+
     public Deposit saveDeposit(Deposit deposit) {
         Optional<DepositEntity> optionalEntity = depositJpaRepository.findByMemberCode(deposit.getMemberCode());
 

--- a/contract-service/src/main/java/com/example/contractservice/deposit/repository/batch/DepositBatchRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/repository/batch/DepositBatchRepository.java
@@ -22,7 +22,7 @@ public class DepositBatchRepository {
 
     private final JdbcTemplate jdbcTemplate;
 
-    public void updateAllDeposits(Map<String, Deposit> memberDepositMap) { // now() 쓰면 데이터베이스 기준 시간대 시간이 들어감
+    public void updateAllDeposits(Map<String, Deposit> memberDepositMap) {
         String sql = """
                 UPDATE deposits
                 SET amount = ?, updated_at = ?
@@ -32,10 +32,10 @@ public class DepositBatchRepository {
         Instant batchTime = Instant.now();
 
         List<Object[]> args = memberDepositMap.values().stream()
-                .map(deposit -> new Object[]{deposit.getAmount(), batchTime, deposit.getCode(), deposit.getUpdatedAt()}).toList();
+                .map(deposit -> new Object[]{deposit.getAmount(), batchTime, deposit.getCode(), deposit.getUpdatedAt()})
+                .toList();
 
         int[] updatedCounts = jdbcTemplate.batchUpdate(sql, args);
-
         boolean allDepositUpdated = Arrays.stream(updatedCounts).allMatch(i -> i == EXPECTED_UPDATED_NUM);
 
         if (!allDepositUpdated) {
@@ -62,5 +62,4 @@ public class DepositBatchRepository {
 
         jdbcTemplate.batchUpdate(sql, args);
     }
-
 }

--- a/contract-service/src/main/java/com/example/contractservice/deposit/service/DepositPendingService.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/service/DepositPendingService.java
@@ -13,4 +13,8 @@ public class DepositPendingService {
     public void save(DepositPendingSaveRequest depositPendingSaveRequest) {
         depositPendingRepository.save(depositPendingSaveRequest.toDomain());
     }
+
+    public boolean cancelPendingByContractCode(String contractCode) {
+        return depositPendingRepository.cancelPendingByContractCode(contractCode);
+    }
 }

--- a/contract-service/src/main/java/com/example/contractservice/deposit/service/DepositPendingService.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/service/DepositPendingService.java
@@ -1,0 +1,16 @@
+package com.example.contractservice.deposit.service;
+
+import com.example.contractservice.deposit.repository.DepositPendingRepository;
+import com.example.contractservice.deposit.service.dto.request.DepositPendingSaveRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DepositPendingService {
+    private final DepositPendingRepository depositPendingRepository;
+
+    public void save(DepositPendingSaveRequest depositPendingSaveRequest) {
+        depositPendingRepository.save(depositPendingSaveRequest.toDomain());
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/service/batch/DepositPendingBatchService.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/service/batch/DepositPendingBatchService.java
@@ -1,0 +1,110 @@
+package com.example.contractservice.deposit.service.batch;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DeadlockLoserDataAccessException;
+import org.springframework.dao.PessimisticLockingFailureException;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DepositPendingBatchService {
+
+    private static final int MAX_CHUNK_RETRY_COUNT = 3;
+    private static final long[] RETRY_DELAY_JITTER_MILLIS = {1000L, 3000L, 5000L};
+
+    private final DepositPendingChunkService depositPendingChunkService;
+
+    @Value("${batch.deposit-pending.size}")
+    private int batchSize;
+
+    @Scheduled(cron = "${batch.deposit-pending.interval}", zone = "UTC")
+    public void processDailyDepositPendings() {
+        Instant startedAt = Instant.now();
+        Instant executionMidnight = LocalDate.now(ZoneOffset.UTC)
+                .atStartOfDay()
+                .toInstant(ZoneOffset.UTC);
+        Instant cutoff = executionMidnight.minus(7, ChronoUnit.DAYS);
+
+        int totalRead = 0;
+        int totalSuccess = 0;
+        int totalFailed = 0;
+        int chunkCount = 0;
+
+        log.info("[deposit-pending-batch] scheduler triggered. executionMidnight={}, cutoff={}, batchSize={}",
+                executionMidnight, cutoff, batchSize);
+
+        while (true) {
+            DepositPendingChunkService.ChunkResult chunkResult;
+
+            try {
+                chunkResult = processChunkWithRetry(cutoff, chunkCount);
+            } catch (RuntimeException e) {
+                log.error("[deposit-pending-batch] aborted. chunkIndex={}, totalRead={}, totalSuccess={}, totalFailed={}",
+                        chunkCount, totalRead, totalSuccess, totalFailed, e);
+                break;
+            }
+
+            if (chunkResult.readCount() == 0) {
+                break;
+            }
+
+            chunkCount++;
+            totalRead += chunkResult.readCount();
+            totalSuccess += chunkResult.successCount();
+            totalFailed += chunkResult.failedCount();
+
+            if (chunkResult.readCount() < batchSize) {
+                break;
+            }
+        }
+
+        log.info("[deposit-pending-batch] end. chunkCount={}, totalRead={}, totalSuccess={}, totalFailed={}, durationMs={}",
+                chunkCount, totalRead, totalSuccess, totalFailed, Duration.between(startedAt, Instant.now()).toMillis());
+    }
+
+    private DepositPendingChunkService.ChunkResult processChunkWithRetry(
+            Instant cutoff,
+            int chunkIndex
+    ) {
+        for (int attempt = 1; attempt <= MAX_CHUNK_RETRY_COUNT; attempt++) {
+            try {
+                return depositPendingChunkService.processChunk(cutoff);
+            } catch (RuntimeException e) {
+                if (!isRetryable(e) || attempt == MAX_CHUNK_RETRY_COUNT) {
+                    throw e;
+                }
+
+                log.warn("[deposit-pending-batch] chunk retry. chunkIndex={}, attempt={}/{}",
+                        chunkIndex, attempt, MAX_CHUNK_RETRY_COUNT, e);
+                sleep(RETRY_DELAY_JITTER_MILLIS[attempt - 1]);
+            }
+        }
+
+        throw new IllegalStateException("Unreachable batch retry state");
+    }
+
+    private boolean isRetryable(RuntimeException exception) {
+        return exception instanceof DataAccessException;
+    }
+
+    private void sleep(long delayMillis) {
+        try {
+            Thread.sleep(delayMillis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Deposit pending batch retry interrupted", e);
+        }
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/service/batch/DepositPendingChunkService.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/service/batch/DepositPendingChunkService.java
@@ -1,0 +1,115 @@
+package com.example.contractservice.deposit.service.batch;
+
+import com.example.contractservice.deposit.domain.Deposit;
+import com.example.contractservice.deposit.domain.DepositHistory;
+import com.example.contractservice.deposit.domain.DepositPending;
+import com.example.contractservice.deposit.domain.vo.DepositChange;
+import com.example.contractservice.deposit.repository.DepositPendingRepository;
+import com.example.contractservice.deposit.repository.DepositRepository;
+import com.example.contractservice.deposit.repository.batch.DepositBatchRepository;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DepositPendingChunkService {
+
+    private static final DateTimeFormatter SUMMARY_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    private final DepositPendingRepository depositPendingRepository;
+    private final DepositRepository depositRepository;
+    private final DepositBatchRepository depositBatchRepository;
+
+    @Value("${admin.member.code}")
+    private String adminMemberCode;
+
+    @Value("${batch.deposit-pending.size}")
+    private int batchSize;
+
+    @Transactional
+    public ChunkResult processChunk(Instant cutoff) {
+        List<DepositPending> depositPendings = depositPendingRepository.findPendingBeforeWithLock(cutoff, batchSize);
+
+        if (depositPendings.isEmpty()) {
+            log.info("[deposit-pending-batch] no due rows in current chunk. cutoff={}", cutoff);
+            return ChunkResult.empty();
+        }
+
+        Deposit adminDeposit = depositRepository.findDepositByMemberCodeForUpdate(adminMemberCode);
+        Instant processedAt = Instant.now();
+
+        int successCount = 0;
+        int failedCount = 0;
+        List<Long> completedIds = new ArrayList<>();
+        List<Long> failedIds = new ArrayList<>();
+        List<DepositHistory> depositHistories = new ArrayList<>();
+
+        for (DepositPending depositPending : depositPendings) {
+            if (depositPending.isInvalidAmount()) {
+                DepositPending failedPending = depositPending.fail(processedAt);
+                failedIds.add(failedPending.getId());
+                failedCount++;
+                log.warn("[deposit-pending-batch] invalid pending amount. id={}, contractCode={}, amount={}",
+                        failedPending.getId(), failedPending.getContractCode(), failedPending.getAmount());
+                continue;
+            }
+
+            DepositPending completedPending = depositPending.complete(processedAt);
+            completedIds.add(completedPending.getId());
+            successCount++;
+
+            if (!completedPending.hasPositiveAmount()) {
+                continue;
+            }
+
+            adminDeposit.transfer(completedPending.getAmount());
+            depositHistories.add(new DepositHistory(
+                    adminDeposit.getCode(),
+                    completedPending.getContractCode(),
+                    new DepositChange(completedPending.getAmount(), adminDeposit.getAmount()),
+                    buildSummary(completedPending.getCreatedAt())
+            ));
+        }
+
+        if (!depositHistories.isEmpty()) {
+            depositBatchRepository.updateAllDeposits(Map.of(adminMemberCode, adminDeposit));
+            depositBatchRepository.saveAllHistories(depositHistories);
+        }
+
+        if (!completedIds.isEmpty()) {
+            depositPendingRepository.markCompletedByIds(completedIds, processedAt);
+        }
+        if (!failedIds.isEmpty()) {
+            depositPendingRepository.markFailedByIds(failedIds, processedAt);
+        }
+
+        log.info("[deposit-pending-batch] chunk processed. readCount={}, successCount={}, failedCount={}",
+                depositPendings.size(), successCount, failedCount);
+
+        return new ChunkResult(depositPendings.size(), successCount, failedCount);
+    }
+
+    private String buildSummary(Instant createdAt) {
+        return createdAt.atOffset(ZoneOffset.UTC).toLocalDate().format(SUMMARY_DATE_FORMATTER) + " 결제 건 배치 입금";
+    }
+
+    public record ChunkResult(
+            int readCount,
+            int successCount,
+            int failedCount
+    ) {
+        public static ChunkResult empty() {
+            return new ChunkResult(0, 0, 0);
+        }
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/service/dto/request/DepositPendingSaveRequest.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/service/dto/request/DepositPendingSaveRequest.java
@@ -1,0 +1,14 @@
+package com.example.contractservice.deposit.service.dto.request;
+
+import com.example.contractservice.deposit.domain.DepositPending;
+import com.example.contractservice.deposit.domain.vo.DepositPendingDetails;
+
+public record DepositPendingSaveRequest(
+        Long amount,
+        String contractCode
+) {
+
+    public DepositPending toDomain() {
+        return new DepositPending(contractCode, new DepositPendingDetails(amount));
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/deposit/service/mapper/DepositPendingMapper.java
+++ b/contract-service/src/main/java/com/example/contractservice/deposit/service/mapper/DepositPendingMapper.java
@@ -1,0 +1,33 @@
+package com.example.contractservice.deposit.service.mapper;
+
+import com.example.contractservice.deposit.domain.DepositPending;
+import com.example.contractservice.deposit.domain.vo.DepositPendingDetails;
+import com.example.contractservice.deposit.entity.DepositPendingEntity;
+
+public abstract class DepositPendingMapper {
+
+    private DepositPendingMapper() {}
+
+    public static DepositPendingEntity toEntity(DepositPending depositPending) {
+        return DepositPendingEntity.create(
+                depositPending.getContractCode(),
+                depositPending.getDepositPendingDetails().getAmount()
+        );
+    }
+
+    public static DepositPending toDomain(DepositPendingEntity depositPendingEntity) {
+        DepositPendingDetails pendingDetails = new DepositPendingDetails(
+                depositPendingEntity.getAmount(),
+                depositPendingEntity.getStatus(),
+                depositPendingEntity.getProcessedAt()
+        );
+
+        return new DepositPending(
+                depositPendingEntity.getId(),
+                depositPendingEntity.getCreatedAt(),
+                depositPendingEntity.getUpdatedAt(),
+                depositPendingEntity.getContractCode(),
+                pendingDetails
+        );
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/settlement/domain/exception/SettlementErrorCode.java
+++ b/contract-service/src/main/java/com/example/contractservice/settlement/domain/exception/SettlementErrorCode.java
@@ -6,12 +6,13 @@ import org.springframework.http.HttpStatus;
 public class SettlementErrorCode extends DomainErrorCode {
     public static final SettlementErrorCode FEE_NOT_CALCULATED;
     public static final DomainErrorCode SETTLEMENT_NOT_EXISTS;
+    public static final DomainErrorCode SETTLEMENT_ALREADY_PROCESSED;
     public static final DomainErrorCode SETTLEMENT_BATCH_UPDATE_FAILED;
 
     static {
         FEE_NOT_CALCULATED = new SettlementErrorCode(HttpStatus.BAD_REQUEST, 4200, "정산 수수료가 계산되지 않았습니다.");
         SETTLEMENT_NOT_EXISTS = new SettlementErrorCode(HttpStatus.BAD_REQUEST, 4201, "해당하는 정산 데이터가 존재하지 않습니다.");
-
+        SETTLEMENT_ALREADY_PROCESSED = new SettlementErrorCode(HttpStatus.BAD_REQUEST, 4202, "이미 정산이 진행되었습니다.");
         SETTLEMENT_BATCH_UPDATE_FAILED = new SettlementErrorCode(HttpStatus.INTERNAL_SERVER_ERROR, 4210, "정산 데이터를 배치 업데이트 하는 중에 일부 레코드가 업데이트 되지 못했습니다.");
     }
 

--- a/contract-service/src/main/java/com/example/contractservice/settlement/repository/SettlementJpaRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/settlement/repository/SettlementJpaRepository.java
@@ -1,5 +1,6 @@
 package com.example.contractservice.settlement.repository;
 
+import com.example.contractservice.settlement.common.SettlementStatus;
 import com.example.contractservice.settlement.entity.SettlementEntity;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,10 +12,16 @@ public interface SettlementJpaRepository extends JpaRepository<SettlementEntity,
     Optional<SettlementEntity> findByCode(String code);
 
     @Modifying
-    @Query("""
-        DELETE
-        FROM SettlementEntity s
-        WHERE s.contractCode = :contractCode
-    """)
-    void deleteByContractCode(String contractCode);
+    @Query(value = """
+        DELETE s
+        FROM settlements s
+        LEFT JOIN settlements blocked
+               ON blocked.contract_code = s.contract_code
+              AND blocked.status = :blockedStatus
+        WHERE s.contract_code = :contractCode
+          AND blocked.contract_code IS NULL
+    """, nativeQuery = true)
+    int deleteCancelableByContractCode(String contractCode, String blockedStatus);
+
+    boolean existsByContractCodeAndStatus(String contractCode, SettlementStatus status);
 }

--- a/contract-service/src/main/java/com/example/contractservice/settlement/repository/SettlementRepository.java
+++ b/contract-service/src/main/java/com/example/contractservice/settlement/repository/SettlementRepository.java
@@ -1,11 +1,15 @@
 package com.example.contractservice.settlement.repository;
 
-import static com.example.contractservice.settlement.service.mapper.SettlementMapper.*;
+import static com.example.contractservice.settlement.domain.exception.SettlementErrorCode.SETTLEMENT_ALREADY_PROCESSED;
+import static com.example.contractservice.settlement.domain.exception.SettlementErrorCode.SETTLEMENT_NOT_EXISTS;
+import static com.example.contractservice.settlement.service.mapper.SettlementMapper.applyToEntity;
+import static com.example.contractservice.settlement.service.mapper.SettlementMapper.toDomain;
+import static com.example.contractservice.settlement.service.mapper.SettlementMapper.toEntity;
 
+import com.example.contractservice.settlement.common.SettlementStatus;
 import com.example.contractservice.settlement.domain.Settlement;
+import com.example.contractservice.settlement.domain.exception.SettlementException;
 import com.example.contractservice.settlement.entity.SettlementEntity;
-import com.example.contractservice.settlement.service.mapper.SettlementMapper;
-import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -30,15 +34,19 @@ public class SettlementRepository {
         return toDomain(settlementJpaRepository.save(settlementEntity));
     }
 
-    public void saveAll(List<Settlement> settlements) {
-        List<SettlementEntity> settlementEntities = settlements.stream()
-                .map(SettlementMapper::toEntity)
-                .toList();
+    public void deleteCancelableSettlementsByContractCode(String contractCode) {
+        int deletedCount = settlementJpaRepository.deleteCancelableByContractCode(contractCode, SettlementStatus.DONE.name());
 
-        settlementJpaRepository.saveAll(settlementEntities);
-    }
+        if (deletedCount > 0) { // 정상적으로 삭제
+            return;
+        }
 
-    public void hardDeleteAllBy(String contractCode) {
-        settlementJpaRepository.deleteByContractCode(contractCode);
+        // 이미 정산 처리 되었는지 최종 확인 (모종의 이유로 정산 데이터가 없었을 수도 있기 때문)
+        if (settlementJpaRepository.existsByContractCodeAndStatus(contractCode, SettlementStatus.DONE)) {
+            throw new SettlementException(SETTLEMENT_ALREADY_PROCESSED);
+        }
+
+        // 정상적이지 않은 흐름(정산 데이터 없음)
+        throw new SettlementException(SETTLEMENT_NOT_EXISTS);
     }
 }

--- a/contract-service/src/main/java/com/example/contractservice/settlement/service/SettlementService.java
+++ b/contract-service/src/main/java/com/example/contractservice/settlement/service/SettlementService.java
@@ -70,7 +70,7 @@ public class SettlementService {
         return settlements;
     }
 
-    public void deleteAllRelatedWith(Contract contract) {
-        settlementRepository.hardDeleteAllBy(contract.getCode());
+    public void deleteCancelableSettlements(Contract contract) {
+        settlementRepository.deleteCancelableSettlementsByContractCode(contract.getCode());
     }
 }

--- a/contract-service/src/test/java/com/example/contractservice/common/controller/DomainExceptionHandlerTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/common/controller/DomainExceptionHandlerTest.java
@@ -1,0 +1,47 @@
+package com.example.contractservice.common.controller;
+
+import static com.example.contractservice.settlement.domain.exception.SettlementErrorCode.SETTLEMENT_NOT_EXISTS;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.contractservice.settlement.domain.exception.SettlementException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.stereotype.Controller;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+class DomainExceptionHandlerTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new SettlementExceptionTestController())
+                .setControllerAdvice(new DomainExceptionHandler())
+                .build();
+    }
+
+    @Test
+    @DisplayName("SettlementException ? ?꾨찓???덉쇅 ?묐떟?쇰줈 留ㅽ븨?쒕떎")
+    void map_settlement_exception_to_domain_error_response() throws Exception {
+        mockMvc.perform(get("/settlement-exception-test"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(4201))
+                .andExpect(jsonPath("$.httpStatus").value(400));
+    }
+
+    @Controller
+    static class SettlementExceptionTestController {
+
+        @ResponseBody
+        @GetMapping("/settlement-exception-test")
+        public void throwSettlementException() {
+            throw new SettlementException(SETTLEMENT_NOT_EXISTS);
+        }
+    }
+}

--- a/contract-service/src/test/java/com/example/contractservice/common/controller/GlobalExceptionHandlerTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/common/controller/GlobalExceptionHandlerTest.java
@@ -1,0 +1,61 @@
+package com.example.contractservice.common.controller;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.stereotype.Controller;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+class GlobalExceptionHandlerTest {
+
+    private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new ValidationTestController())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    @Test
+    @DisplayName("MethodArgumentNotValidException ? HTTP 400 ?쇰줈 ?묐떟?쒕떎")
+    void return_bad_request_for_method_argument_not_valid_exception() throws Exception {
+        mockMvc.perform(post("/validation-test")
+                        .contentType(APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.httpStatus").value(400))
+                .andExpect(jsonPath("$.code").value(4999));
+    }
+
+    @Controller
+    static class ValidationTestController {
+
+        @ResponseBody
+        @PostMapping("/validation-test")
+        public ValidationResponse validate(@Valid @RequestBody ValidationRequest request) {
+            return new ValidationResponse(request.name());
+        }
+    }
+
+    record ValidationRequest(@NotBlank String name) {
+    }
+
+    record ValidationResponse(String name) {
+    }
+}

--- a/contract-service/src/test/java/com/example/contractservice/contract/common/ContractPaySettlementTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/contract/common/ContractPaySettlementTest.java
@@ -13,6 +13,7 @@ import com.example.contractservice.contract.service.dto.request.ContractPayProce
 import com.example.contractservice.deposit.entity.DepositEntity;
 import com.example.contractservice.deposit.repository.DepositHistoryJpaRepository;
 import com.example.contractservice.deposit.repository.DepositJpaRepository;
+import com.example.contractservice.deposit.repository.DepositPendingJpaRepository;
 import com.example.contractservice.settlement.common.SettlementStatus;
 import com.example.contractservice.settlement.domain.Settlement;
 import com.example.contractservice.settlement.entity.SettlementEntity;
@@ -39,9 +40,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.kafka.core.KafkaAdmin;
-import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 @Import(TestConfig.class)
@@ -60,11 +58,8 @@ class ContractPaySettlementTest {
     ContractJpaRepository contractJpaRepository;
     @Autowired
     private DepositHistoryJpaRepository depositHistoryJpaRepository;
-
-    @MockitoBean
-    KafkaTemplate<String, String> kafkaTemplate;
-    @MockitoBean
-    KafkaAdmin kafkaAdmin;
+    @Autowired
+    private DepositPendingJpaRepository depositPendingJpaRepository;
 
     @Value("${admin.member.code}")
     String adminMemberCode;
@@ -75,10 +70,11 @@ class ContractPaySettlementTest {
 
     @AfterEach
     void tearDown() {
-        depositJpaRepository.deleteAllInBatch();
+        depositPendingJpaRepository.deleteAllInBatch();
         depositHistoryJpaRepository.deleteAllInBatch();
-        contractJpaRepository.deleteAllInBatch();
         settlementJpaRepository.deleteAllInBatch();
+        contractJpaRepository.deleteAllInBatch();
+        depositJpaRepository.deleteAllInBatch();
         commissionsCapacityJpaRepository.deleteAllInBatch();
     }
 
@@ -194,7 +190,7 @@ class ContractPaySettlementTest {
         System.out.println(settlementSuccessCount.get());
 
         assertEquals(initAmount - paySuccessCount.get() * paymentAmount + settlementSuccessCount.get() * settledAmount, afterUserDeposit.getAmount());
-        assertEquals(initAmount + paySuccessCount.get() * paymentAmount - settlementSuccessCount.get() * settledAmount, afterAdminDeposit.getAmount());
+        assertEquals(initAmount - settlementSuccessCount.get() * settledAmount, afterAdminDeposit.getAmount());
         assertTrue(paySuccessCount.get() > 0);
     }
 }

--- a/contract-service/src/test/java/com/example/contractservice/contract/service/ContractCancelServiceTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/contract/service/ContractCancelServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.contractservice.contract.service;
 
+import static com.example.contractservice.contract.domain.exception.ContractErrorCode.CANCEL_NOT_AVAILABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -52,7 +53,7 @@ class ContractCancelServiceTest {
     private ContractCancelService contractCancelService;
 
     @Test
-    @DisplayName("PAID 계약 취소에 성공하면 deposit pending을 CANCELLED로 처리하고 회원 예치금을 환불한다")
+    @DisplayName("PAID 怨꾩빟 痍⑥냼???깃났?섎㈃ deposit pending??CANCELLED濡?泥섎━?섍퀬 ?뚯썝 ?덉튂湲덉쓣 ?섎텋?쒕떎")
     void success_process_cancel_paid_contract_when_pending_is_pending() {
         // given
         String clientCode = UUID.randomUUID().toString();
@@ -104,7 +105,7 @@ class ContractCancelServiceTest {
     }
 
     @Test
-    @DisplayName("PAID 계약의 deposit pending이 이미 COMPLETED면 취소에 실패한다")
+    @DisplayName("PAID 怨꾩빟??deposit pending???대? COMPLETED硫?痍⑥냼???ㅽ뙣?쒕떎")
     void fail_process_cancel_paid_contract_when_pending_is_completed() {
         // given
         String clientCode = UUID.randomUUID().toString();
@@ -132,8 +133,10 @@ class ContractCancelServiceTest {
         when(depositPendingService.cancelPendingByContractCode(contractCode)).thenReturn(false);
 
         // when & then
-        assertThrows(ContractException.class, () -> contractCancelService.processCancel(contract));
+        ContractException exception = assertThrows(ContractException.class,
+                () -> contractCancelService.processCancel(contract));
 
+        assertEquals(CANCEL_NOT_AVAILABLE, exception.getErrorCode());
         verify(depositPendingService).cancelPendingByContractCode(contractCode);
         verify(depositService, never()).getDepositHistoryForRefund(any(), any());
         verify(depositService, never()).transfer(any());

--- a/contract-service/src/test/java/com/example/contractservice/contract/service/ContractCancelServiceTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/contract/service/ContractCancelServiceTest.java
@@ -53,9 +53,8 @@ class ContractCancelServiceTest {
     private ContractCancelService contractCancelService;
 
     @Test
-    @DisplayName("PAID 怨꾩빟 痍⑥냼???깃났?섎㈃ deposit pending??CANCELLED濡?泥섎━?섍퀬 ?뚯썝 ?덉튂湲덉쓣 ?섎텋?쒕떎")
+    @DisplayName("PAID 계약 취소에 성공하면 deposit pending을 CANCELLED로 처리하고 회원 예치금을 환불한다")
     void success_process_cancel_paid_contract_when_pending_is_pending() {
-        // given
         String clientCode = UUID.randomUUID().toString();
         String freelancerCode = UUID.randomUUID().toString();
         String contractCode = UUID.randomUUID().toString();
@@ -85,10 +84,8 @@ class ContractCancelServiceTest {
         when(depositService.getDepositHistoryForRefund(clientCode, contractCode))
                 .thenReturn(new DepositHistoryInfo(Instant.now(), -amount, 700_000L, "payment"));
 
-        // when
         contractCancelService.processCancel(contract);
 
-        // then
         ArgumentCaptor<DepositProcessRequest> refundCaptor = ArgumentCaptor.forClass(DepositProcessRequest.class);
 
         verify(depositPendingService).cancelPendingByContractCode(contractCode);
@@ -105,9 +102,8 @@ class ContractCancelServiceTest {
     }
 
     @Test
-    @DisplayName("PAID 怨꾩빟??deposit pending???대? COMPLETED硫?痍⑥냼???ㅽ뙣?쒕떎")
+    @DisplayName("PAID 계약의 deposit pending이 이미 COMPLETED면 취소에 실패한다")
     void fail_process_cancel_paid_contract_when_pending_is_completed() {
-        // given
         String clientCode = UUID.randomUUID().toString();
         String freelancerCode = UUID.randomUUID().toString();
         String contractCode = UUID.randomUUID().toString();
@@ -132,7 +128,6 @@ class ContractCancelServiceTest {
 
         when(depositPendingService.cancelPendingByContractCode(contractCode)).thenReturn(false);
 
-        // when & then
         ContractException exception = assertThrows(ContractException.class,
                 () -> contractCancelService.processCancel(contract));
 

--- a/contract-service/src/test/java/com/example/contractservice/contract/service/ContractCancelServiceTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/contract/service/ContractCancelServiceTest.java
@@ -1,0 +1,143 @@
+package com.example.contractservice.contract.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.contractservice.contract.common.ContractStatus;
+import com.example.contractservice.contract.controller.dto.response.CommissionCapacityResponse;
+import com.example.contractservice.contract.domain.Contract;
+import com.example.contractservice.contract.domain.exception.ContractException;
+import com.example.contractservice.contract.domain.vo.ContractContent;
+import com.example.contractservice.contract.domain.vo.ContractInfo;
+import com.example.contractservice.contract.repository.ContractRepository;
+import com.example.contractservice.deposit.controller.dto.response.DepositHistoryInfo;
+import com.example.contractservice.deposit.service.DepositPendingService;
+import com.example.contractservice.deposit.service.DepositService;
+import com.example.contractservice.deposit.service.dto.request.DepositProcessRequest;
+import com.example.contractservice.settlement.service.SettlementService;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import org.hexagon.core.vo.PaymentType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class ContractCancelServiceTest {
+
+    @Mock
+    private DepositService depositService;
+    @Mock
+    private DepositPendingService depositPendingService;
+    @Mock
+    private SettlementService settlementService;
+    @Mock
+    private ContractRepository contractRepository;
+    @Mock
+    private CommissionsCapacityService commissionsCapacityService;
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @InjectMocks
+    private ContractCancelService contractCancelService;
+
+    @Test
+    @DisplayName("PAID 계약 취소에 성공하면 deposit pending을 CANCELLED로 처리하고 회원 예치금을 환불한다")
+    void success_process_cancel_paid_contract_when_pending_is_pending() {
+        // given
+        String clientCode = UUID.randomUUID().toString();
+        String freelancerCode = UUID.randomUUID().toString();
+        String contractCode = UUID.randomUUID().toString();
+        String commissionCode = UUID.randomUUID().toString();
+        long amount = 300_000L;
+
+        Contract contract = new Contract(
+                contractCode,
+                new ContractInfo(
+                        clientCode,
+                        freelancerCode,
+                        commissionCode,
+                        Instant.now().plus(1, ChronoUnit.DAYS),
+                        Instant.now().plus(31, ChronoUnit.DAYS),
+                        PaymentType.PER_JOB,
+                        amount,
+                        ContractStatus.PAID
+                ),
+                new ContractContent("name", "body"),
+                Instant.now(),
+                Instant.now()
+        );
+
+        when(depositPendingService.cancelPendingByContractCode(contractCode)).thenReturn(true);
+        when(commissionsCapacityService.getCapacity(commissionCode))
+                .thenReturn(new CommissionCapacityResponse(10, 5, 5, 3));
+        when(depositService.getDepositHistoryForRefund(clientCode, contractCode))
+                .thenReturn(new DepositHistoryInfo(Instant.now(), -amount, 700_000L, "payment"));
+
+        // when
+        contractCancelService.processCancel(contract);
+
+        // then
+        ArgumentCaptor<DepositProcessRequest> refundCaptor = ArgumentCaptor.forClass(DepositProcessRequest.class);
+
+        verify(depositPendingService).cancelPendingByContractCode(contractCode);
+        verify(depositService).transfer(refundCaptor.capture());
+        verify(depositService, never()).withdraw(any());
+        verify(settlementService).deleteCancelableSettlements(contract);
+        verify(contractRepository).saveContract(contract);
+        verify(applicationEventPublisher).publishEvent(any(Object.class));
+
+        assertEquals(clientCode, refundCaptor.getValue().memberCode());
+        assertEquals(contractCode, refundCaptor.getValue().contractCode());
+        assertEquals(amount, refundCaptor.getValue().amount());
+        assertEquals(ContractStatus.CANCELLED, contract.getInfo().status());
+    }
+
+    @Test
+    @DisplayName("PAID 계약의 deposit pending이 이미 COMPLETED면 취소에 실패한다")
+    void fail_process_cancel_paid_contract_when_pending_is_completed() {
+        // given
+        String clientCode = UUID.randomUUID().toString();
+        String freelancerCode = UUID.randomUUID().toString();
+        String contractCode = UUID.randomUUID().toString();
+        String commissionCode = UUID.randomUUID().toString();
+
+        Contract contract = new Contract(
+                contractCode,
+                new ContractInfo(
+                        clientCode,
+                        freelancerCode,
+                        commissionCode,
+                        Instant.now().plus(1, ChronoUnit.DAYS),
+                        Instant.now().plus(31, ChronoUnit.DAYS),
+                        PaymentType.PER_JOB,
+                        300_000L,
+                        ContractStatus.PAID
+                ),
+                new ContractContent("name", "body"),
+                Instant.now(),
+                Instant.now()
+        );
+
+        when(depositPendingService.cancelPendingByContractCode(contractCode)).thenReturn(false);
+
+        // when & then
+        assertThrows(ContractException.class, () -> contractCancelService.processCancel(contract));
+
+        verify(depositPendingService).cancelPendingByContractCode(contractCode);
+        verify(depositService, never()).getDepositHistoryForRefund(any(), any());
+        verify(depositService, never()).transfer(any());
+        verify(settlementService, never()).deleteCancelableSettlements(any());
+        verify(contractRepository, never()).saveContract(any());
+    }
+}

--- a/contract-service/src/test/java/com/example/contractservice/contract/service/ContractInternalServiceTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/contract/service/ContractInternalServiceTest.java
@@ -17,9 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.kafka.core.KafkaAdmin;
-import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 @Import(TestConfig.class)
@@ -28,11 +25,6 @@ class ContractInternalServiceTest {
     ContractService contractService;
     @Autowired
     private ContractJpaRepository contractJpaRepository;
-
-    @MockitoBean
-    KafkaTemplate<String, String> kafkaTemplate;
-    @MockitoBean
-    KafkaAdmin kafkaAdmin;
 
     @AfterEach
     void tearDown() {

--- a/contract-service/src/test/java/com/example/contractservice/contract/service/ContractPayServiceTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/contract/service/ContractPayServiceTest.java
@@ -1,0 +1,106 @@
+package com.example.contractservice.contract.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.contractservice.contract.common.ContractStatus;
+import com.example.contractservice.contract.domain.Contract;
+import com.example.contractservice.contract.domain.vo.ContractContent;
+import com.example.contractservice.contract.domain.vo.ContractInfo;
+import com.example.contractservice.contract.entity.CommissionsCapacity;
+import com.example.contractservice.contract.repository.CommissionsCapacityRepository;
+import com.example.contractservice.contract.repository.ContractRepository;
+import com.example.contractservice.contract.service.dto.request.ContractPayProcessRequest;
+import com.example.contractservice.deposit.service.DepositPendingService;
+import com.example.contractservice.deposit.service.DepositService;
+import com.example.contractservice.deposit.service.dto.request.DepositPendingSaveRequest;
+import com.example.contractservice.deposit.service.dto.request.DepositProcessRequest;
+import com.example.contractservice.settlement.service.SettlementService;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import org.hexagon.core.vo.PaymentType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class ContractPayServiceTest {
+
+    @Mock
+    private DepositService depositService;
+    @Mock
+    private DepositPendingService depositPendingService;
+    @Mock
+    private SettlementService settlementService;
+    @Mock
+    private ContractRepository contractRepository;
+    @Mock
+    private CommissionsCapacityRepository commissionsCapacityRepository;
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @InjectMocks
+    private ContractPayService contractPayService;
+
+    @Test
+    @DisplayName("결제 처리에 성공하면 사용자 출금 후 관리자 입금 pending을 저장한다")
+    void success_process_payment_saves_pending_instead_of_admin_deposit_update() {
+        // given
+        String clientCode = UUID.randomUUID().toString();
+        String freelancerCode = UUID.randomUUID().toString();
+        String contractCode = UUID.randomUUID().toString();
+        String commissionCode = UUID.randomUUID().toString();
+        long unitAmount = 150_000L;
+
+        Contract contract = new Contract(
+                contractCode,
+                new ContractInfo(
+                        clientCode,
+                        freelancerCode,
+                        commissionCode,
+                        Instant.now().plus(1, ChronoUnit.DAYS),
+                        Instant.now().plus(31, ChronoUnit.DAYS),
+                        PaymentType.PER_JOB,
+                        unitAmount,
+                        ContractStatus.REQUESTED
+                ),
+                new ContractContent("name", "body"),
+                Instant.now(),
+                Instant.now()
+        );
+        CommissionsCapacity capacity = CommissionsCapacity.createBy(commissionCode, 10, 5);
+
+        when(contractRepository.findByCode(contractCode)).thenReturn(contract);
+        when(commissionsCapacityRepository.findByCommissionCode(commissionCode)).thenReturn(capacity);
+
+        // when
+        contractPayService.processPayment(new ContractPayProcessRequest(clientCode, contractCode));
+
+        // then
+        ArgumentCaptor<DepositProcessRequest> withdrawCaptor = ArgumentCaptor.forClass(DepositProcessRequest.class);
+        ArgumentCaptor<DepositPendingSaveRequest> pendingCaptor = ArgumentCaptor.forClass(DepositPendingSaveRequest.class);
+
+        verify(depositService).withdraw(withdrawCaptor.capture());
+        verify(depositPendingService).save(pendingCaptor.capture());
+        verify(contractRepository).saveContract(any(Contract.class));
+        verify(settlementService).savePaidSettlements(any());
+        verify(commissionsCapacityRepository).saveCapacity(capacity);
+        verify(applicationEventPublisher).publishEvent(any(Object.class));
+
+        assertEquals(clientCode, withdrawCaptor.getValue().memberCode());
+        assertEquals(contractCode, withdrawCaptor.getValue().contractCode());
+        assertEquals(unitAmount, withdrawCaptor.getValue().amount());
+        assertEquals(unitAmount, pendingCaptor.getValue().amount());
+        assertEquals(contractCode, pendingCaptor.getValue().contractCode());
+        assertEquals(ContractStatus.PAID, contract.getInfo().status());
+        assertEquals(1, capacity.getSelectedCount());
+    }
+}

--- a/contract-service/src/test/java/com/example/contractservice/contract/service/ContractReadServiceTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/contract/service/ContractReadServiceTest.java
@@ -33,8 +33,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.kafka.core.KafkaAdmin;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
@@ -46,14 +44,8 @@ class ContractReadServiceTest {
     private ContractJpaRepository contractJpaRepository;
     @Autowired
     private ContractReadService contractReadService;
-
     @MockitoBean
     MemberClient memberClient;
-
-    @MockitoBean
-    KafkaTemplate<String, String> kafkaTemplate;
-    @MockitoBean
-    KafkaAdmin kafkaAdmin;
 
     private String memberCode;
 

--- a/contract-service/src/test/java/com/example/contractservice/contract/service/ContractServiceTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/contract/service/ContractServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.contractservice.contract.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -24,19 +25,24 @@ import com.example.contractservice.contract.service.dto.response.MemberInfoRespo
 import com.example.contractservice.contract.service.dto.response.MemberInfoResponse.MemberInfo;
 import com.example.contractservice.contract.service.dto.response.MemberInfoResponse.MemberRole;
 import com.example.contractservice.contract.service.mapper.ContractMapper;
+import com.example.contractservice.deposit.common.DepositPendingStatus;
 import com.example.contractservice.deposit.entity.DepositEntity;
+import com.example.contractservice.deposit.entity.DepositPendingEntity;
 import com.example.contractservice.deposit.repository.DepositHistoryJpaRepository;
 import com.example.contractservice.deposit.repository.DepositJpaRepository;
+import com.example.contractservice.deposit.repository.DepositPendingJpaRepository;
 import com.example.contractservice.settlement.entity.SettlementEntity;
 import com.example.contractservice.settlement.repository.SettlementJpaRepository;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.hexagon.core.dto.ResponseDto;
 import org.hexagon.core.vo.PaymentType;
@@ -49,8 +55,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
-import org.springframework.kafka.core.KafkaAdmin;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
@@ -68,10 +72,6 @@ class ContractServiceTest {
     CommissionsCapacityJpaRepository commissionsCapacityJpaRepository;
 
     @MockitoBean
-    KafkaTemplate<String, String> kafkaTemplate;
-    @MockitoBean
-    KafkaAdmin kafkaAdmin;
-    @MockitoBean
     MemberClient memberClient;
     @MockitoBean
     CommissionClient commissionClient;
@@ -80,19 +80,28 @@ class ContractServiceTest {
     String adminMemberCode;
     @Autowired
     private DepositHistoryJpaRepository depositHistoryJpaRepository;
+    @Autowired
+    private DepositPendingJpaRepository depositPendingJpaRepository;
 
     @BeforeEach
     void setUp() {
+        depositPendingJpaRepository.deleteAllInBatch();
+        depositHistoryJpaRepository.deleteAllInBatch();
+        settlementJpaRepository.deleteAllInBatch();
+        contractJpaRepository.deleteAllInBatch();
+        commissionsCapacityJpaRepository.deleteAllInBatch();
+        depositJpaRepository.deleteAllInBatch();
         depositJpaRepository.save(DepositEntity.createBy(adminMemberCode));
     }
 
     @AfterEach
     void tearDown() {
-        contractJpaRepository.deleteAllInBatch();
-        depositJpaRepository.deleteAllInBatch();
-        settlementJpaRepository.deleteAllInBatch();
+        depositPendingJpaRepository.deleteAllInBatch();
         depositHistoryJpaRepository.deleteAllInBatch();
+        settlementJpaRepository.deleteAllInBatch();
+        contractJpaRepository.deleteAllInBatch();
         commissionsCapacityJpaRepository.deleteAllInBatch();
+        depositJpaRepository.deleteAllInBatch();
     }
 
     @Test
@@ -149,10 +158,20 @@ class ContractServiceTest {
 
         // then - 2개 실패 필요
         DepositEntity adminDeposit = depositJpaRepository.findByMemberCode(adminMemberCode).get();
+        DepositEntity paidUserDeposit = depositJpaRepository.findByMemberCode(userCode).get();
+        List<DepositPendingEntity> depositPendings = depositPendingJpaRepository.findAll();
+        Set<String> successContractCodes = contractPayResponse.success().stream().collect(Collectors.toSet());
 
         assertEquals(normalLimit, contractPayResponse.success().size());
         assertEquals(entireTestNum - normalLimit, contractPayResponse.fail().size());
-        assertEquals(unitAmount * normalLimit, adminDeposit.getAmount());
+        assertEquals(0L, adminDeposit.getAmount());
+        assertEquals((long) Integer.MAX_VALUE - (unitAmount * normalLimit), paidUserDeposit.getAmount());
+        assertEquals(normalLimit, depositPendings.size());
+        assertTrue(depositPendings.stream().allMatch(pending -> pending.getStatus() == DepositPendingStatus.PENDING));
+        assertTrue(depositPendings.stream().allMatch(pending -> pending.getAmount().equals(unitAmount)));
+        assertEquals(successContractCodes, depositPendings.stream()
+                .map(DepositPendingEntity::getContractCode)
+                .collect(Collectors.toSet()));
     }
 
     @Test
@@ -194,6 +213,15 @@ class ContractServiceTest {
 
         contractService.payContracts(new ContractPayServiceRequest(clientCode, contracts.stream().map(Contract::getCode).toList())); // 계약 결제 처리
 
+        List<DepositPendingEntity> paidPendings = depositPendingJpaRepository.findAll();
+        Set<String> contractCodes = contracts.stream().map(Contract::getCode).collect(Collectors.toSet());
+
+        assertEquals(contractsNum, paidPendings.size());
+        assertTrue(paidPendings.stream().allMatch(pending -> pending.getStatus() == DepositPendingStatus.PENDING));
+        assertEquals(contractCodes, paidPendings.stream()
+                .map(DepositPendingEntity::getContractCode)
+                .collect(Collectors.toSet()));
+
         // when
         List<ContractCancelRequest> requests = List.of(
                 new ContractCancelRequest(clientCode, contracts.get(0).getCode()), // 클라이언트가 취소하는 경우
@@ -206,9 +234,15 @@ class ContractServiceTest {
         DepositEntity adminDeposit = depositJpaRepository.findByMemberCode(adminMemberCode).get();
         DepositEntity clientDeposit = depositJpaRepository.findByMemberCode(clientCode).get();
         List<SettlementEntity> allSettlements = settlementJpaRepository.findAll();
+        List<DepositPendingEntity> cancelledPendings = depositPendingJpaRepository.findAll();
 
         assertEquals(0L, adminDeposit.getAmount());
         assertEquals(unitAmount * contractsNum, clientDeposit.getAmount());
+        assertEquals(contractsNum, cancelledPendings.size());
+        assertTrue(cancelledPendings.stream().allMatch(pending -> pending.getStatus() == DepositPendingStatus.CANCELLED));
+        assertEquals(contractCodes, cancelledPendings.stream()
+                .map(DepositPendingEntity::getContractCode)
+                .collect(Collectors.toSet()));
         assertEquals(0, allSettlements.size());
     }
 
@@ -230,9 +264,9 @@ class ContractServiceTest {
         ExecutorService threadPool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
         CountDownLatch countDownLatch = new CountDownLatch(tryCount);
 
-        List<MemberInfo> memberInfoList = List.of(new MemberInfo(clientCode, "클라이언트", MemberRole.CLIENT),
+        List<MemberInfo> memberInfoList = List.of(
+                new MemberInfo(clientCode, "클라이언트", MemberRole.CLIENT),
                 new MemberInfo(freelancerCode, "프리랜서", MemberRole.FREELANCER));
-
         when(memberClient.getMemberInfo(any()))
                 .thenReturn(new ResponseDto<>(0, HttpStatus.OK.value(), "", new MemberInfoResponse(memberInfoList)));
         when(commissionClient.getRecruitmentStatus(commissionCode))

--- a/contract-service/src/test/java/com/example/contractservice/contract/service/event/ContractKafkaHandlerTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/contract/service/event/ContractKafkaHandlerTest.java
@@ -16,9 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.kafka.core.KafkaAdmin;
-import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 @Import(TestConfig.class)
@@ -27,11 +24,6 @@ class ContractKafkaHandlerTest {
     ContractJpaRepository contractRepository;
     @Autowired
     ContractEventService contractEventService;
-
-    @MockitoBean
-    KafkaTemplate<String, String> kafkaTemplate;
-    @MockitoBean
-    KafkaAdmin kafkaAdmin;
 
     @AfterEach
     void tearDown() {

--- a/contract-service/src/test/java/com/example/contractservice/deposit/domain/DepositPendingTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/deposit/domain/DepositPendingTest.java
@@ -1,0 +1,45 @@
+package com.example.contractservice.deposit.domain;
+
+import static com.example.contractservice.deposit.domain.exception.DepositErrorCode.INVALID_PENDING_STATUS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.example.contractservice.deposit.common.DepositPendingStatus;
+import com.example.contractservice.deposit.domain.exception.DepositException;
+import com.example.contractservice.deposit.domain.vo.DepositPendingDetails;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DepositPendingTest {
+
+    @Test
+    @DisplayName("PENDING 상태가 아닌 DepositPending 데이터는 complete 할 수 없다")
+    void fail_complete_when_status_is_not_pending() {
+        DepositPending depositPending = new DepositPending(
+                1L,
+                "contract-code",
+                new DepositPendingDetails(100L, DepositPendingStatus.COMPLETED, Instant.now())
+        );
+
+        DepositException exception = assertThrows(DepositException.class,
+                () -> depositPending.complete(Instant.now()));
+
+        assertEquals(INVALID_PENDING_STATUS, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("PENDING 상태가 아닌 DepositPending 데이터는 fail 할 수 없다")
+    void fail_fail_when_status_is_not_pending() {
+        DepositPending depositPending = new DepositPending(
+                1L,
+                "contract-code",
+                new DepositPendingDetails(100L, DepositPendingStatus.FAILED, Instant.now())
+        );
+
+        DepositException exception = assertThrows(DepositException.class,
+                () -> depositPending.fail(Instant.now()));
+
+        assertEquals(INVALID_PENDING_STATUS, exception.getErrorCode());
+    }
+}

--- a/contract-service/src/test/java/com/example/contractservice/deposit/service/DepositServiceTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/deposit/service/DepositServiceTest.java
@@ -29,9 +29,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.kafka.core.KafkaAdmin;
-import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 @Import(TestConfig.class)
@@ -44,11 +41,6 @@ class DepositServiceTest {
     DepositJpaRepository depositRepository;
     @Autowired
     DepositHistoryJpaRepository depositHistoryJpaRepository;
-
-    @MockitoBean
-    KafkaTemplate<String, String> kafkaTemplate;
-    @MockitoBean
-    KafkaAdmin kafkaAdmin;
 
     Random random = new Random();
 

--- a/contract-service/src/test/java/com/example/contractservice/deposit/service/batch/DepositPendingBatchServiceTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/deposit/service/batch/DepositPendingBatchServiceTest.java
@@ -1,0 +1,43 @@
+package com.example.contractservice.deposit.service.batch;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.RecoverableDataAccessException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class DepositPendingBatchServiceTest {
+
+    @Mock
+    private DepositPendingChunkService depositPendingChunkService;
+
+    private DepositPendingBatchService depositPendingBatchService;
+
+    @BeforeEach
+    void setUp() {
+        depositPendingBatchService = new DepositPendingBatchService(depositPendingChunkService);
+        ReflectionTestUtils.setField(depositPendingBatchService, "batchSize", 500);
+    }
+
+    @Test
+    @DisplayName("DB 일시 오류는 chunk 단위로 최대 3회까지 재시도한다")
+    void success_retry_chunk_on_data_access_exception() {
+        when(depositPendingChunkService.processChunk(any()))
+                .thenThrow(new RecoverableDataAccessException("retry-1"))
+                .thenThrow(new RecoverableDataAccessException("retry-2"))
+                .thenReturn(DepositPendingChunkService.ChunkResult.empty());
+
+        depositPendingBatchService.processDailyDepositPendings();
+
+        verify(depositPendingChunkService, times(3)).processChunk(any());
+    }
+}

--- a/contract-service/src/test/java/com/example/contractservice/deposit/service/batch/DepositPendingChunkServiceTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/deposit/service/batch/DepositPendingChunkServiceTest.java
@@ -1,0 +1,130 @@
+package com.example.contractservice.deposit.service.batch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.contractservice.deposit.common.DepositPendingStatus;
+import com.example.contractservice.deposit.domain.Deposit;
+import com.example.contractservice.deposit.domain.DepositHistory;
+import com.example.contractservice.deposit.domain.DepositPending;
+import com.example.contractservice.deposit.domain.vo.DepositPendingDetails;
+import com.example.contractservice.deposit.repository.DepositPendingRepository;
+import com.example.contractservice.deposit.repository.DepositRepository;
+import com.example.contractservice.deposit.repository.batch.DepositBatchRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class DepositPendingChunkServiceTest {
+
+    @Mock
+    private DepositPendingRepository depositPendingRepository;
+    @Mock
+    private DepositRepository depositRepository;
+    @Mock
+    private DepositBatchRepository depositBatchRepository;
+
+    private DepositPendingChunkService depositPendingChunkService;
+
+    @BeforeEach
+    void setUp() {
+        depositPendingChunkService = new DepositPendingChunkService(
+                depositPendingRepository,
+                depositRepository,
+                depositBatchRepository
+        );
+        ReflectionTestUtils.setField(depositPendingChunkService, "adminMemberCode", "admin-code");
+        ReflectionTestUtils.setField(depositPendingChunkService, "batchSize", 500);
+    }
+
+    @Test
+    @DisplayName("금액이 양수인 DepositPending 데이터는 관리자 예치금과 히스토리에 반영되고 COMPLETED 처리된다")
+    void success_process_chunk_completes_positive_rows() {
+        DepositPending pending1 = createPending(1L, "contract-1", 100L, Instant.parse("2026-02-20T00:00:00Z"));
+        DepositPending pending2 = createPending(2L, "contract-2", 200L, Instant.parse("2026-02-21T00:00:00Z"));
+        Deposit adminDeposit = new Deposit("deposit-code", Instant.now(), Instant.now(), "admin-code", 1000L);
+
+        when(depositPendingRepository.findPendingBeforeWithLock(any(), eq(500))).thenReturn(List.of(pending1, pending2));
+        when(depositRepository.findDepositByMemberCodeForUpdate("admin-code")).thenReturn(adminDeposit);
+
+        DepositPendingChunkService.ChunkResult result = depositPendingChunkService.processChunk(Instant.now().minusSeconds(1));
+
+        assertEquals(2, result.readCount());
+        assertEquals(2, result.successCount());
+        assertEquals(0, result.failedCount());
+        assertEquals(DepositPendingStatus.PENDING, pending1.getStatus());
+        assertEquals(DepositPendingStatus.PENDING, pending2.getStatus());
+
+        ArgumentCaptor<Map<String, Deposit>> depositMapCaptor = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<List<DepositHistory>> historiesCaptor = ArgumentCaptor.forClass(List.class);
+        verify(depositBatchRepository).updateAllDeposits(depositMapCaptor.capture());
+        assertEquals(1300L, depositMapCaptor.getValue().get("admin-code").getAmount());
+        verify(depositBatchRepository).saveAllHistories(historiesCaptor.capture());
+        assertEquals("2026-02-20 결제 건 배치 입금", historiesCaptor.getValue().get(0).getSummary());
+        verify(depositPendingRepository).markCompletedByIds(eq(List.of(1L, 2L)), any());
+        verify(depositPendingRepository, never()).markFailedByIds(any(), any());
+    }
+
+    @Test
+    @DisplayName("금액이 0원인 DepositPending 데이터는 COMPLETED 처리되지만 히스토리 기록은 생략된다")
+    void success_complete_zero_amount_without_history() {
+        DepositPending pending = createPending(1L, "contract-1", 0L, Instant.parse("2026-02-20T00:00:00Z"));
+        Deposit adminDeposit = new Deposit("deposit-code", Instant.now(), Instant.now(), "admin-code", 1000L);
+
+        when(depositPendingRepository.findPendingBeforeWithLock(any(), eq(500))).thenReturn(List.of(pending));
+        when(depositRepository.findDepositByMemberCodeForUpdate("admin-code")).thenReturn(adminDeposit);
+
+        DepositPendingChunkService.ChunkResult result = depositPendingChunkService.processChunk(Instant.now().minusSeconds(1));
+
+        assertEquals(1, result.successCount());
+        assertEquals(0, result.failedCount());
+        assertEquals(DepositPendingStatus.PENDING, pending.getStatus());
+        verify(depositBatchRepository, never()).updateAllDeposits(any());
+        verify(depositBatchRepository, never()).saveAllHistories(any());
+        verify(depositPendingRepository).markCompletedByIds(eq(List.of(1L)), any());
+        verify(depositPendingRepository, never()).markFailedByIds(any(), any());
+    }
+
+    @Test
+    @DisplayName("금액이 음수인 DepositPending 데이터는 FAILED 처리된다")
+    void success_mark_failed_for_negative_amount() {
+        DepositPending pending = createPending(1L, "contract-1", -100L, Instant.parse("2026-02-20T00:00:00Z"));
+        Deposit adminDeposit = new Deposit("deposit-code", Instant.now(), Instant.now(), "admin-code", 1000L);
+
+        when(depositPendingRepository.findPendingBeforeWithLock(any(), eq(500))).thenReturn(List.of(pending));
+        when(depositRepository.findDepositByMemberCodeForUpdate("admin-code")).thenReturn(adminDeposit);
+
+        DepositPendingChunkService.ChunkResult result = depositPendingChunkService.processChunk(Instant.now().minusSeconds(1));
+
+        assertEquals(0, result.successCount());
+        assertEquals(1, result.failedCount());
+        assertEquals(DepositPendingStatus.PENDING, pending.getStatus());
+        verify(depositBatchRepository, never()).updateAllDeposits(any());
+        verify(depositBatchRepository, never()).saveAllHistories(any());
+        verify(depositPendingRepository, never()).markCompletedByIds(any(), any());
+        verify(depositPendingRepository).markFailedByIds(eq(List.of(1L)), any());
+    }
+
+    private DepositPending createPending(Long id, String contractCode, Long amount, Instant createdAt) {
+        return new DepositPending(
+                id,
+                createdAt,
+                createdAt,
+                contractCode,
+                new DepositPendingDetails(amount, DepositPendingStatus.PENDING, null)
+        );
+    }
+}

--- a/contract-service/src/test/java/com/example/contractservice/settlement/service/SettlementServiceTest.java
+++ b/contract-service/src/test/java/com/example/contractservice/settlement/service/SettlementServiceTest.java
@@ -27,9 +27,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.kafka.core.KafkaAdmin;
-import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 @Import(TestConfig.class)
@@ -46,11 +43,6 @@ class SettlementServiceTest {
     String adminMemberCode;
     @Value("${batch.settlement.settlement-rate}")
     BigDecimal settlementRate;
-
-    @MockitoBean
-    KafkaTemplate<String, String> kafkaTemplate;
-    @MockitoBean
-    KafkaAdmin kafkaAdmin;
 
     @AfterEach
     void tearDown() {


### PR DESCRIPTION
## 🐛 관련 이슈

Closes #7

## 📌 목적
- 결제 시점과 정산 시점에 관리자 예치금으로 쓰기 부하가 집중되던 구조를 분리하기 위해, 결제 직후 관리자 예치금을 즉시 증가시키지 않고 `deposit_pending`에 적재한 뒤 지연 배치로 반영하도록 변경했습니다.
- 이슈 본문은 정산 시 결제 이력을 관리자 예치금에 반영하는 방향을 설명하고 있었지만, 실제 구현은 결제 후 7일이 지난 pending 데이터를 배치로 반영하는 방식입니다. 관리자 예치금 hotspot 분리라는 핵심 목적은 유지하면서도, 정산 전에 관리자 예치금을 미리 확보할 수 있도록 바꿨습니다.
- 결제 취소 시에는 pending 취소, 환불, 취소 가능한 정산 데이터 삭제를 함께 처리해 결제, 취소, 정산 간 정합성을 맞췄습니다.

## ✅ 변경 사항

### 변경 사항 정리
- 결제 플로우를 변경했습니다.
  - 클라이언트 예치금은 즉시 차감하되, 관리자 예치금으로 바로 송금하지 않고 `DepositPending`을 저장하도록 변경했습니다.
- 관리자 예치금 지연 반영 배치를 추가했습니다.
  - `UTC 자정 - 7일` 이전의 pending 데이터를 읽어 관리자 예치금과 예치금 히스토리를 일괄 반영합니다.
  - DB 일시 오류는 chunk 단위로 최대 3회까지 재시도하도록 구성했습니다.
- 취소 롤백을 보강했습니다.
  - 결제 완료 계약 취소 시 `PENDING` 상태의 pending 데이터를 `CANCELLED`로 변경하고, 클라이언트 환불과 취소 가능한 정산 데이터 삭제를 함께 처리합니다.
  - 이미 배치 반영이 끝나 `COMPLETED` 상태가 된 pending 데이터는 취소 대상이 아니며, 이 경우 계약 취소를 허용하지 않도록 정책을 테스트로 고정했습니다.
- 정산 삭제 로직과 예외 응답을 보강했습니다.
  - 이미 `DONE` 상태 정산이 존재하는 경우와 삭제 대상 정산 자체가 없는 경우를 구분해 `SettlementException`을 던지도록 했고, 해당 예외가 일반 500이 아니라 도메인 응답으로 매핑되도록 보완했습니다.
- 입력 검증 예외 응답을 정리했습니다.
  - `MethodArgumentNotValidException`은 클라이언트 입력 오류이므로 HTTP 400으로 응답하도록 정리했습니다.
- 동시성 제어를 추가했습니다.
  - pending 조회는 `FOR UPDATE SKIP LOCKED`, 관리자 예치금 조회는 `PESSIMISTIC_WRITE`, 최종 deposit batch update는 `updated_at` 조건 기반 optimistic update로 충돌을 감지하도록 구성했습니다.
- 테스트를 보강했습니다.
  - 결제 시 pending 저장, 취소 시 pending 취소 및 정산 삭제, `COMPLETED` 상태 취소 불가, 배치 재시도, chunk 성공/실패, 예외 응답 매핑 케이스를 검증하는 테스트를 추가했습니다.

### 변경/추가된 프로젝트 구조
```text
deposit/
├─ common/
│  └─ DepositPendingStatus
├─ domain/
│  ├─ DepositPending
│  └─ vo/
│     └─ DepositPendingDetails
├─ entity/
│  └─ DepositPendingEntity
├─ repository/
│  ├─ DepositPendingJpaRepository
│  └─ DepositPendingRepository
└─ service/
   ├─ DepositPendingService
   ├─ dto/request/
   │  └─ DepositPendingSaveRequest
   ├─ mapper/
   │  └─ DepositPendingMapper
   └─ batch/
      ├─ DepositPendingBatchService
      └─ DepositPendingChunkService

test/
├─ common/controller/
│  ├─ DomainExceptionHandlerTest
│  └─ GlobalExceptionHandlerTest
├─ contract/service/
│  ├─ ContractCancelServiceTest
│  └─ ContractPayServiceTest
└─ deposit/
   ├─ domain/
   │  └─ DepositPendingTest
   └─ service/batch/
      ├─ DepositPendingBatchServiceTest
      └─ DepositPendingChunkServiceTest
```

### 핵심 로직

#### 핵심 로직 1 - 결제 시 관리자 예치금 직접 반영 제거
결제 요청에서는 관리자 예치금을 즉시 증가시키지 않고, 관리자 반영 대상 금액만 `DepositPending`으로 저장합니다.  
이 로직이 필요한 이유는 결제 시점의 관리자 예치금 직접 갱신을 제거해, 관리자 예치금 row 하나에 쓰기 부하가 몰리는 구조를 끊기 위해서입니다.  
이 변경으로 결제 트래픽과 관리자 예치금 반영 시점을 분리할 수 있습니다.

```java
DepositProcessRequest depositProcessRequest = new DepositProcessRequest(
        xCode,
        contract.getCode(),
        totalAmount,
        PAYMENT_COMMENT
);
depositService.withdraw(depositProcessRequest);

depositPendingService.save(new DepositPendingSaveRequest(totalAmount, contract.getCode()));
```

#### 핵심 로직 2 - 병렬 처리 안정성 및 충돌 회피
배치에서는 처리 대상 pending row를 `FOR UPDATE SKIP LOCKED`로 조회합니다.  
이 쿼리가 필요한 이유는 여러 실행 주체가 동시에 배치를 수행하더라도 같은 pending row를 중복 처리하지 않게 하기 위해서입니다.  
잠긴 row를 건너뛰므로, 배치 중복 실행 상황에서도 충돌을 줄이고 병렬 처리 안정성을 확보할 수 있습니다.

```sql
SELECT *
FROM deposit_pendings dp
WHERE dp.status = :status
  AND dp.created_at < :cutoff
ORDER BY dp.status, dp.created_at
LIMIT :limit
FOR UPDATE SKIP LOCKED
```

#### 핵심 로직 3 - 지연 반영 데이터의 일관된 상태 전이
배치 chunk 처리에서는 관리자 예치금을 비관적 락으로 잡은 뒤, pending 데이터를 관리자 예치금과 히스토리에 반영하고 상태를 완료 처리합니다.  
이 로직이 필요한 이유는 지연 반영된 금액이 실제 관리자 잔액과 이력에 함께 기록되어야 하고, 처리 완료 여부도 동일 흐름 안에서 일관되게 전이되어야 하기 때문입니다.  
이로 인해 관리자 예치금, 히스토리, pending 상태 간 정합성을 유지할 수 있습니다.

```java
Deposit adminDeposit = depositRepository.findDepositByMemberCodeForUpdate(adminMemberCode);
Instant processedAt = Instant.now();

for (DepositPending depositPending : depositPendings) {
    DepositPending completedPending = depositPending.complete(processedAt);
    completedIds.add(completedPending.getId());

    if (!completedPending.hasPositiveAmount()) {
        continue;
    }

    adminDeposit.transfer(completedPending.getAmount());
    depositHistories.add(new DepositHistory(
            adminDeposit.getCode(),
            completedPending.getContractCode(),
            new DepositChange(completedPending.getAmount(), adminDeposit.getAmount()),
            buildSummary(completedPending.getCreatedAt())
    ));
}
```

## 🧪 테스트 방법
- 실행한 전체 테스트 명령
  - `JDK 17 (Temurin) 환경에서 .\gradlew.bat test`
- 수동 시나리오
  - 결제 성공 시 클라이언트 예치금이 차감되고 관리자 예치금은 즉시 증가하지 않으며 `deposit_pendings`에 `PENDING` row가 생성되는지 확인
  - 생성 시각이 7일 지난 pending 데이터에 대해 배치를 실행했을 때 관리자 예치금 증가, `deposit_histories` 저장, pending `COMPLETED` 전환이 함께 일어나는지 확인
  - 결제 후 배치 반영 전 계약 취소 시 pending 이 `CANCELLED`로 바뀌고 클라이언트 환불 및 취소 가능한 정산 데이터 삭제가 함께 처리되는지 확인
  - 배치 반영 후 `COMPLETED` 상태 pending 데이터에 대해서는 계약 취소가 거절되는지 확인
  - 정산 삭제 과정에서 발생하는 `SettlementException`이 500이 아니라 도메인 오류 응답으로 매핑되는지 확인
  - 입력 DTO 검증 실패가 HTTP 400으로 응답되는지 확인
  - 배치를 동시에 2회 이상 실행했을 때 동일 pending row가 중복 반영되지 않는지 확인

## 📎 참고 사항
- 관련 이슈 번호 : #7
- 비교 대상 브랜치는 local branch graph 기준으로 `develop`을 사용했습니다.
- 전체 테스트는 통과했습니다.
- 현재 `feat/contract/7 -> develop` PR은 열려 있으며, assignee는 작성자 계정으로 지정했습니다.
- @codex review
- @claude

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [x] 이슈 번호를 입력 했나요?
- [x] 코드 컨벤션을 모두 지켰나요?
- [x] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?