### PR TITLE
feat(contract): 일자 단위 로깅 및 Slack 장애 알림 연동

### DIFF
--- a/contract-service/build.gradle
+++ b/contract-service/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Caffeine 캐시
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
     // MySQL
     implementation 'com.mysql:mysql-connector-j'
 
@@ -71,6 +74,9 @@ dependencies {
 
     // Feign Client
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // Slack Client API
+    implementation 'com.slack.api:slack-api-client:1.47.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/contract-service/src/main/java/com/example/contractservice/common/filter/MDCFilter.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/filter/MDCFilter.java
@@ -1,0 +1,28 @@
+package com.example.contractservice.common.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class MDCFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            MDC.put("httpMethod", request.getMethod());
+            MDC.put("httpPath", request.getRequestURI());
+
+            doFilter(request, response, filterChain);
+        } finally {
+            MDC.clear();
+        }
+    }
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/common/logging/CaffeineErrorDeduplicator.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/logging/CaffeineErrorDeduplicator.java
@@ -5,11 +5,14 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import java.util.concurrent.TimeUnit;
 
 public class CaffeineErrorDeduplicator implements SlackErrorDeduplicator {
+
+    private static final int MAXIMUM_CACHE_SIZE = 1000;
     private final Cache<String, Boolean> cache;
 
     public CaffeineErrorDeduplicator(int ttlMillis) {
         cache = Caffeine.newBuilder()
                 .expireAfterWrite(ttlMillis, TimeUnit.MILLISECONDS)
+                .maximumSize(MAXIMUM_CACHE_SIZE)
                 .build();
     }
 

--- a/contract-service/src/main/java/com/example/contractservice/common/logging/CaffeineErrorDeduplicator.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/logging/CaffeineErrorDeduplicator.java
@@ -1,0 +1,30 @@
+package com.example.contractservice.common.logging;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.concurrent.TimeUnit;
+
+public class CaffeineErrorDeduplicator implements SlackErrorDeduplicator {
+    private Cache<String, Boolean> cache;
+
+    public CaffeineErrorDeduplicator(int ttlMillis) {
+        cache = Caffeine.newBuilder()
+                .expireAfterWrite(ttlMillis, TimeUnit.MILLISECONDS)
+                .build();
+    }
+
+    @Override
+    public void add(String key) {
+        cache.put(key, true);
+    }
+
+    @Override
+    public boolean isDuplicate(String key) {
+        return cache.getIfPresent(key) != null;
+    }
+
+    @Override
+    public void remove(String key) {
+        cache.invalidate(key);
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/common/logging/CaffeineErrorDeduplicator.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/logging/CaffeineErrorDeduplicator.java
@@ -5,7 +5,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import java.util.concurrent.TimeUnit;
 
 public class CaffeineErrorDeduplicator implements SlackErrorDeduplicator {
-    private Cache<String, Boolean> cache;
+    private final Cache<String, Boolean> cache;
 
     public CaffeineErrorDeduplicator(int ttlMillis) {
         cache = Caffeine.newBuilder()
@@ -14,13 +14,8 @@ public class CaffeineErrorDeduplicator implements SlackErrorDeduplicator {
     }
 
     @Override
-    public void add(String key) {
-        cache.put(key, true);
-    }
-
-    @Override
-    public boolean isDuplicate(String key) {
-        return cache.getIfPresent(key) != null;
+    public boolean acquire(String key) {
+        return cache.asMap().putIfAbsent(key, Boolean.TRUE) == null;
     }
 
     @Override

--- a/contract-service/src/main/java/com/example/contractservice/common/logging/SlackErrorAppender.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/logging/SlackErrorAppender.java
@@ -38,11 +38,8 @@ public class SlackErrorAppender extends AppenderBase<ILoggingEvent> {
         String rootCauseClass = getRootCauseClass(throwableProxy);
         String key = assembleDedupKey(mdcMap, event, rootCauseClass);
 
-        synchronized (this) {
-            if (errorDeduplicator.isDuplicate(key))
-                return;
-            errorDeduplicator.add(key);
-        }
+        if (!errorDeduplicator.acquire(key))
+            return;
 
         SlackErrorInfo dataForSlack = createDataForSlack(mdcMap, event, throwableProxy, rootCauseClass);
 

--- a/contract-service/src/main/java/com/example/contractservice/common/logging/SlackErrorAppender.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/logging/SlackErrorAppender.java
@@ -1,0 +1,106 @@
+package com.example.contractservice.common.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.core.AppenderBase;
+import com.example.contractservice.common.logging.dto.SlackErrorInfo;
+import com.example.contractservice.common.util.StringUtil;
+import java.util.Map;
+
+public class SlackErrorAppender extends AppenderBase<ILoggingEvent> {
+    private static final String NO_VAL = "none";
+    private static final int LIMIT = 3;
+
+    private String webhookUrl;
+    private int ttlMillis;
+    private int connectionTimeoutMillis;
+    private int readTimeoutMillis;
+
+    private SlackErrorDeduplicator errorDeduplicator;
+    private SlackSender slackSender;
+
+    @Override
+    public void start() {
+        if (ttlMillis <= 0 || connectionTimeoutMillis <= 0 || readTimeoutMillis <= 0)
+            return;
+
+        super.start();
+        errorDeduplicator = new CaffeineErrorDeduplicator(ttlMillis);
+        slackSender = new SlackSender(webhookUrl, connectionTimeoutMillis, readTimeoutMillis);
+    }
+
+    // 오케스트레이터. 캐시 검증, MDC와 이벤트로부터 데이터 조합 후, 슬랙 센더에 전달
+    @Override
+    protected void append(ILoggingEvent event) {
+        Map<String, String> mdcMap = event.getMDCPropertyMap();
+        String key = assembleVal(mdcMap, event);
+
+        synchronized (this) {
+            if (errorDeduplicator.isDuplicate(key))
+                return;
+            errorDeduplicator.add(key);
+        }
+
+        SlackErrorInfo dataForSlack = createDataForSlack(mdcMap, event);
+
+        try {
+            slackSender.send(dataForSlack);
+        } catch (Exception e) { // 전송 실패 예외 시
+            errorDeduplicator.remove(key);
+        }
+    }
+
+    // method + path + callerName + ExceptionName
+    private String assembleVal(Map<String, String> mdcMap, ILoggingEvent event) {
+        return StringUtil.format("{}:{}:{}:{}",
+                mdcMap.getOrDefault("httpMethod", NO_VAL),
+                mdcMap.getOrDefault("httpPath", NO_VAL),
+                event.getLoggerName(),
+                event.getThrowableProxy().getClassName()
+        );
+    }
+
+    private SlackErrorInfo createDataForSlack(Map<String, String> mdcMap, ILoggingEvent event) {
+        return new SlackErrorInfo(
+                mdcMap.getOrDefault("httpMethod", NO_VAL),
+                mdcMap.getOrDefault("httpPath", NO_VAL),
+                event.getLoggerName(),
+                getBriefException(event.getThrowableProxy())
+        );
+    }
+
+    // 중첩 예외 최대 3개까지 최상단부터 출력
+    private String getBriefException(IThrowableProxy proxy) {
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < LIMIT; i++) {
+            if (proxy == null)
+                break;
+
+            if (i > 0)
+                sb.append("at ");
+
+            sb.append(proxy.getClassName()).append(":").append(proxy.getMessage()).append("\n");
+            proxy = proxy.getCause();
+        }
+
+        return sb.toString();
+    }
+
+    // setter
+    public void setWebhookUrl(String webhookUrl) {
+        this.webhookUrl = webhookUrl;
+    }
+
+    public void setTtlMillis(int ttlMillis) {
+        this.ttlMillis = ttlMillis;
+    }
+
+    public void setConnectionTimeoutMillis(int connectionTimeoutMillis) {
+        this.connectionTimeoutMillis = connectionTimeoutMillis;
+    }
+
+    public void setReadTimeoutMillis(int readTimeoutMillis) {
+        this.readTimeoutMillis = readTimeoutMillis;
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/common/logging/SlackErrorAppender.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/logging/SlackErrorAppender.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 public class SlackErrorAppender extends AppenderBase<ILoggingEvent> {
     private static final String NO_VAL = "none";
+    private static final String NO_THROWABLE = "NO_THROWABLE";
     private static final int LIMIT = 3;
 
     private String webhookUrl;
@@ -33,7 +34,9 @@ public class SlackErrorAppender extends AppenderBase<ILoggingEvent> {
     @Override
     protected void append(ILoggingEvent event) {
         Map<String, String> mdcMap = event.getMDCPropertyMap();
-        String key = assembleVal(mdcMap, event);
+        IThrowableProxy throwableProxy = event.getThrowableProxy();
+        String rootCauseClass = getRootCauseClass(throwableProxy);
+        String key = assembleDedupKey(mdcMap, event, rootCauseClass);
 
         synchronized (this) {
             if (errorDeduplicator.isDuplicate(key))
@@ -41,7 +44,7 @@ public class SlackErrorAppender extends AppenderBase<ILoggingEvent> {
             errorDeduplicator.add(key);
         }
 
-        SlackErrorInfo dataForSlack = createDataForSlack(mdcMap, event);
+        SlackErrorInfo dataForSlack = createDataForSlack(mdcMap, event, throwableProxy, rootCauseClass);
 
         try {
             slackSender.send(dataForSlack);
@@ -50,22 +53,24 @@ public class SlackErrorAppender extends AppenderBase<ILoggingEvent> {
         }
     }
 
-    // method + path + callerName + ExceptionName
-    private String assembleVal(Map<String, String> mdcMap, ILoggingEvent event) {
-        return StringUtil.format("{}:{}:{}:{}",
-                mdcMap.getOrDefault("httpMethod", NO_VAL),
-                mdcMap.getOrDefault("httpPath", NO_VAL),
-                event.getLoggerName(),
-                event.getThrowableProxy().getClassName()
+    private String assembleDedupKey(Map<String, String> mdcMap, ILoggingEvent event, String rootCauseClass) {
+        return StringUtil.format("method={}||path={}||logger={}||rootCause={}||msg={}",
+                getNormalizedValue(mdcMap.get("httpMethod")),
+                getNormalizedValue(mdcMap.get("httpPath")),
+                getNormalizedValue(event.getLoggerName()),
+                getNormalizedValue(rootCauseClass),
+                getNormalizedValue(event.getMessage())
         );
     }
 
-    private SlackErrorInfo createDataForSlack(Map<String, String> mdcMap, ILoggingEvent event) {
+    private SlackErrorInfo createDataForSlack(Map<String, String> mdcMap, ILoggingEvent event,
+                                              IThrowableProxy throwableProxy, String rootCauseClass) {
         return new SlackErrorInfo(
-                mdcMap.getOrDefault("httpMethod", NO_VAL),
-                mdcMap.getOrDefault("httpPath", NO_VAL),
+                mdcMap.get("httpMethod"),
+                mdcMap.get("httpPath"),
                 event.getLoggerName(),
-                getBriefException(event.getThrowableProxy())
+                throwableProxy == null ? getNormalizedValue(event.getFormattedMessage()) : getBriefException(throwableProxy),
+                throwableProxy == null ? NO_VAL : buildRootCauseSummary(throwableProxy, rootCauseClass)
         );
     }
 
@@ -85,6 +90,38 @@ public class SlackErrorAppender extends AppenderBase<ILoggingEvent> {
         }
 
         return sb.toString();
+    }
+
+    private String buildRootCauseSummary(IThrowableProxy proxy, String rootCauseClass) {
+        IThrowableProxy rootCause = getRootCauseProxy(proxy);
+        return StringUtil.format("{}: {}", rootCauseClass, getNormalizedValue(rootCause.getMessage()));
+    }
+
+    private String getRootCauseClass(IThrowableProxy proxy) {
+        if (proxy == null)
+            return NO_THROWABLE;
+
+        return getRootCauseProxy(proxy).getClassName();
+    }
+
+    private IThrowableProxy getRootCauseProxy(IThrowableProxy proxy) {
+        IThrowableProxy current = proxy;
+
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+
+        return current;
+    }
+
+    private String getNormalizedValue(String value) {
+        if (value == null || value.isBlank())
+            return NO_VAL;
+
+        return value
+                .replace("\r", " ")
+                .replace("\n", " ")
+                .trim();
     }
 
     // setter

--- a/contract-service/src/main/java/com/example/contractservice/common/logging/SlackErrorAppender.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/logging/SlackErrorAppender.java
@@ -22,7 +22,7 @@ public class SlackErrorAppender extends AppenderBase<ILoggingEvent> {
 
     @Override
     public void start() {
-        if (ttlMillis <= 0 || connectionTimeoutMillis <= 0 || readTimeoutMillis <= 0)
+        if (ttlMillis <= 0 || connectionTimeoutMillis <= 0 || readTimeoutMillis <= 0 || webhookUrl == null || webhookUrl.isBlank())
             return;
 
         super.start();

--- a/contract-service/src/main/java/com/example/contractservice/common/logging/SlackErrorDeduplicator.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/logging/SlackErrorDeduplicator.java
@@ -1,0 +1,7 @@
+package com.example.contractservice.common.logging;
+
+public interface SlackErrorDeduplicator {
+    void add(String key);
+    boolean isDuplicate(String key);
+    void remove(String key);
+}

--- a/contract-service/src/main/java/com/example/contractservice/common/logging/SlackErrorDeduplicator.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/logging/SlackErrorDeduplicator.java
@@ -1,7 +1,6 @@
 package com.example.contractservice.common.logging;
 
 public interface SlackErrorDeduplicator {
-    void add(String key);
-    boolean isDuplicate(String key);
+    boolean acquire(String key);
     void remove(String key);
 }

--- a/contract-service/src/main/java/com/example/contractservice/common/logging/SlackSender.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/logging/SlackSender.java
@@ -3,20 +3,16 @@ package com.example.contractservice.common.logging;
 import com.example.contractservice.common.logging.dto.SlackErrorInfo;
 import com.example.contractservice.common.util.StringUtil;
 import com.slack.api.SlackConfig;
-import com.slack.api.model.Attachment;
-import com.slack.api.model.Field;
 import com.slack.api.util.json.GsonFactory;
 import com.slack.api.webhook.Payload;
 import java.time.Duration;
-import java.util.List;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 public class SlackSender {
-    private static final String COLOR = "#ff0000";
-    private static final String EXCEPTION_TITLE = "예외 발생";
-    private static final String ROOT_CAUSE_FORMAT = "root cause: {}";
+    private static final String EXCEPTION_TITLE = "에러 발생";
+    private static final String ALERT_TEXT = "에러가 발생했습니다! 빠른 처리가 필요합니다!";
 
     private final String webhookUrl;
     private final RestClient restClient;
@@ -47,25 +43,9 @@ public class SlackSender {
         }
     }
 
-    private static String getPayload(SlackErrorInfo info) {
-        List<Field> fields = List.of(
-                Field.builder()
-                        .title(resolveTitle(info))
-                        .value(StringUtil.format("발생 클래스: {} \n예외: {}\n{}",
-                                info.loggingClass(),
-                                info.exceptionSummary(),
-                                StringUtil.format(ROOT_CAUSE_FORMAT, info.rootCause())))
-                        .build()
-        );
-        List<Attachment> attachments = List.of(
-                Attachment.builder()
-                        .color(COLOR)
-                        .fields(fields)
-                        .build()
-        );
+    private String getPayload(SlackErrorInfo info) {
         Payload payload = Payload.builder()
-                .text("에러가 발생했습니다! 빠른 처리가 필요합니다!")
-                .attachments(attachments)
+                .text(buildText(info))
                 .build();
 
         return GsonFactory
@@ -83,5 +63,16 @@ public class SlackSender {
 
     private static boolean isBlank(String value) {
         return value == null || value.isBlank();
+    }
+
+    private String buildText(SlackErrorInfo info) {
+        StringBuilder sb = new StringBuilder()
+                .append(ALERT_TEXT).append("\n\n")
+                .append("*:red_circle:").append(resolveTitle(info)).append("*\n")
+                .append(StringUtil.format("발생 클래스: {}", info.loggingClass())).append("\n")
+                .append(StringUtil.format("예외: {}", info.exceptionSummary())).append("\n")
+                .append(StringUtil.format("root cause: {}", info.rootCause()));
+
+        return sb.toString();
     }
 }

--- a/contract-service/src/main/java/com/example/contractservice/common/logging/SlackSender.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/logging/SlackSender.java
@@ -15,9 +15,11 @@ import org.springframework.web.client.RestClient;
 
 public class SlackSender {
     private static final String COLOR = "#ff0000";
+    private static final String EXCEPTION_TITLE = "예외 발생";
+    private static final String ROOT_CAUSE_FORMAT = "root cause: {}";
 
-    private String webhookUrl;
-    private RestClient restClient;
+    private final String webhookUrl;
+    private final RestClient restClient;
 
     public SlackSender(String webhookUrl, int connectionTimeoutMillis, int readTimeoutMillis) {
         this.webhookUrl = webhookUrl;
@@ -48,10 +50,11 @@ public class SlackSender {
     private static String getPayload(SlackErrorInfo info) {
         List<Field> fields = List.of(
                 Field.builder()
-                        .title(StringUtil.format("{} {} 요청에서 에러 발생", info.httpMethod(),
-                                info.httpPath()))
-                        .value(StringUtil.format("발생 클래스: {} \n예외: {}", info.loggingClass(),
-                                info.exception()))
+                        .title(resolveTitle(info))
+                        .value(StringUtil.format("발생 클래스: {} \n예외: {}\n{}",
+                                info.loggingClass(),
+                                info.exceptionSummary(),
+                                StringUtil.format(ROOT_CAUSE_FORMAT, info.rootCause())))
                         .build()
         );
         List<Attachment> attachments = List.of(
@@ -68,5 +71,17 @@ public class SlackSender {
         return GsonFactory
                 .createSnakeCase(SlackConfig.DEFAULT)
                 .toJson(payload);
+    }
+
+    private static String resolveTitle(SlackErrorInfo info) {
+        if (isBlank(info.httpMethod()) && isBlank(info.httpPath())) {
+            return EXCEPTION_TITLE;
+        }
+
+        return StringUtil.format("{} {} 요청에서 에러 발생", info.httpMethod(), info.httpPath());
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/contract-service/src/main/java/com/example/contractservice/common/logging/SlackSender.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/logging/SlackSender.java
@@ -1,0 +1,72 @@
+package com.example.contractservice.common.logging;
+
+import com.example.contractservice.common.logging.dto.SlackErrorInfo;
+import com.example.contractservice.common.util.StringUtil;
+import com.slack.api.SlackConfig;
+import com.slack.api.model.Attachment;
+import com.slack.api.model.Field;
+import com.slack.api.util.json.GsonFactory;
+import com.slack.api.webhook.Payload;
+import java.time.Duration;
+import java.util.List;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+public class SlackSender {
+    private static final String COLOR = "#ff0000";
+
+    private String webhookUrl;
+    private RestClient restClient;
+
+    public SlackSender(String webhookUrl, int connectionTimeoutMillis, int readTimeoutMillis) {
+        this.webhookUrl = webhookUrl;
+
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(Duration.ofMillis(connectionTimeoutMillis));
+        requestFactory.setReadTimeout(Duration.ofMillis(readTimeoutMillis));
+
+        restClient = RestClient.builder()
+                .requestFactory(requestFactory)
+                .build();
+    }
+
+    public void send(SlackErrorInfo info) {
+        String payload = getPayload(info);
+
+        String res = restClient.post()
+                .uri(webhookUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(payload)
+                .retrieve().body(String.class);
+
+        if (!"ok".equalsIgnoreCase(res)) {
+            throw new IllegalStateException(StringUtil.format("Slack 알림이 제대로 전달되지 않았거나 타임아웃이 발생했습니다. 응답: {}", res));
+        }
+    }
+
+    private static String getPayload(SlackErrorInfo info) {
+        List<Field> fields = List.of(
+                Field.builder()
+                        .title(StringUtil.format("{} {} 요청에서 에러 발생", info.httpMethod(),
+                                info.httpPath()))
+                        .value(StringUtil.format("발생 클래스: {} \n예외: {}", info.loggingClass(),
+                                info.exception()))
+                        .build()
+        );
+        List<Attachment> attachments = List.of(
+                Attachment.builder()
+                        .color(COLOR)
+                        .fields(fields)
+                        .build()
+        );
+        Payload payload = Payload.builder()
+                .text("에러가 발생했습니다! 빠른 처리가 필요합니다!")
+                .attachments(attachments)
+                .build();
+
+        return GsonFactory
+                .createSnakeCase(SlackConfig.DEFAULT)
+                .toJson(payload);
+    }
+}

--- a/contract-service/src/main/java/com/example/contractservice/common/logging/dto/SlackErrorInfo.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/logging/dto/SlackErrorInfo.java
@@ -1,0 +1,10 @@
+package com.example.contractservice.common.logging.dto;
+
+public record SlackErrorInfo(
+        String httpMethod,
+        String httpPath,
+        String loggingClass,
+        String exception
+) {
+
+}

--- a/contract-service/src/main/java/com/example/contractservice/common/logging/dto/SlackErrorInfo.java
+++ b/contract-service/src/main/java/com/example/contractservice/common/logging/dto/SlackErrorInfo.java
@@ -4,7 +4,8 @@ public record SlackErrorInfo(
         String httpMethod,
         String httpPath,
         String loggingClass,
-        String exception
+        String exceptionSummary,
+        String rootCause
 ) {
 
 }

--- a/contract-service/src/main/resources/application-prod.yml
+++ b/contract-service/src/main/resources/application-prod.yml
@@ -114,9 +114,9 @@ admin:
 
 logging:
   slack:
-    webhook-url: ${SLACK_WEBHOOK_URL}
     deduplication:
       ttl: 1800000
     sender:
       read-timeout: 2000
       connection-timeout: 1000
+      webhook-url: ${SLACK_WEBHOOK_URL}

--- a/contract-service/src/main/resources/application-prod.yml
+++ b/contract-service/src/main/resources/application-prod.yml
@@ -4,10 +4,9 @@ server:
 eureka:
   client:
     serviceUrl:
-      defaultZone: http://eureka-server:8761/eureka/
+      defaultZone: http://${DISCOVERY_HOST}:8761/eureka/
   instance:
     instance-id: "${spring.application.name}:${server.port}:${random.uuid}"
-    hostname: hexagon-contract-service
 spring:
   application:
     name: contract-service
@@ -26,7 +25,7 @@ spring:
 
   datasource:
     # TODO: 프로젝트 환경에 맞게 DB URL, Username, Password 수정 필요!!
-    url: jdbc:mysql://mysql:3306/${MYSQL_DATABASE}?rewriteBatchedStatements=true&connectionTimeout=3000&socketTimeout=10000
+    url: jdbc:mysql://${MYSQL_HOST}:3306/${MYSQL_DATABASE}?rewriteBatchedStatements=true&connectionTimeout=3000&socketTimeout=10000
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${MYSQL_USER}
     password: ${MYSQL_PASSWORD}
@@ -39,7 +38,7 @@ spring:
 
   kafka:
     bootstrap-servers:
-      - kafka:9092
+      - ${KAFKA_HOST}:9092
 
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
@@ -96,6 +95,9 @@ module:
         member-info: /internal/members
 
 batch:
+  deposit-pending:
+    size: 500
+    interval: 0 0 0 * * ?
   settlement:
     size: 500
     settlement-rate: 0.125
@@ -109,3 +111,12 @@ admin:
     code: ${ADMIN_MEMBER_CODE} # 수정 가능
   deposit:
     code: ${ADMIN_DEPOSIT_CODE} # 수정 가능
+
+logging:
+  slack:
+    webhook-url: ${SLACK_WEBHOOK_URL}
+    deduplication:
+      ttl: 1800000
+    sender:
+      read-timeout: 2000
+      connection-timeout: 1000

--- a/contract-service/src/main/resources/logback-spring.xml
+++ b/contract-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <springProperty scope="context" name="APP_NAME" source="spring.application.name" defaultValue="contract-service"/>
+    <springProperty scope="context" name="LOG_PATH" source="logging.file.path" defaultValue="./logs"/>
+    <springProperty scope="context" name="ROOT_LOG_LEVEL" source="logging.level.root" defaultValue="INFO"/>
+
+    <springProperty scope="context" name="SLACK_WEBHOOK_URL" source="logging.slack.sender.webhook-url"/>
+    <springProperty scope="context" name="SLACK_ERROR_TTL" source="logging.slack.deduplication.ttl" defaultValue="1800000"/>
+    <springProperty scope="context" name="SLACK_READ_TIMEOUT" source="logging.slack.sender.read-timeout" defaultValue="2000"/>
+    <springProperty scope="context" name="SLACK_CONNECTION_TIMEOUT" source="logging.slack.sender.connection-timeout" defaultValue="1000"/>
+
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
+    <property name="FILE_LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ROLLING_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/${APP_NAME}.log</file>
+
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/${APP_NAME}.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
+        </rollingPolicy>
+    </appender>
+
+    <appender name="SLACK_ERROR_ALERT" class="com.example.contractservice.common.logging.SlackErrorAppender">
+        <ttlMillis>${SLACK_ERROR_TTL}</ttlMillis>
+        <connectionTimeoutMillis>${SLACK_CONNECTION_TIMEOUT}</connectionTimeoutMillis>
+        <readTimeoutMillis>${SLACK_READ_TIMEOUT}</readTimeoutMillis>
+        <webhookUrl>${SLACK_WEBHOOK_URL}</webhookUrl>
+    </appender>
+
+    <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+        <neverBlock>false</neverBlock>
+        <maxFlushTime>30000</maxFlushTime>
+        <appender-ref ref="SLACK_ERROR_ALERT" />
+    </appender>
+
+    <root level="${ROOT_LOG_LEVEL}">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="ROLLING_FILE"/>
+        <appender-ref ref="ASYNC_SLACK" />
+    </root>
+
+</configuration>

--- a/contract-service/src/main/resources/logback-spring.xml
+++ b/contract-service/src/main/resources/logback-spring.xml
@@ -47,7 +47,7 @@
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>
         </filter>
-        <neverBlock>false</neverBlock>
+        <neverBlock>true</neverBlock>
         <maxFlushTime>30000</maxFlushTime>
         <appender-ref ref="SLACK_ERROR_ALERT" />
     </appender>


### PR DESCRIPTION
## 🐛 관련 이슈
Closes #12

## 📌 목적
- contract-service에 일자 단위 파일 로깅과 Slack 장애 알림 경로를 추가해, 예상치 못한 장애를 운영 중 빠르게 감지할 수 있도록 하는 것이 목적입니다.
- Logback 설정을 통해 파일 로그를 남기고, `ERROR` 레벨 로그를 별도 appender로 분기해 Slack webhook으로 전달하도록 구성했습니다.
- 이슈 본문에 언급된 AI 기반 분석 제안 기능 자체는 이번 PR 범위에 포함하지 않았지만, 장애 메시지를 외부 시스템이 읽기 쉬운 형태로 정리해 후속 자동화나 분석 확장에 대비했습니다.

## ✅ 변경 사항
### 변경 사항 정리
- Logback 설정 파일을 추가해 콘솔 로그와 일자 단위 파일 로그를 함께 남기도록 구성했습니다.
- `ERROR` 로그를 Slack으로 보내는 custom appender를 추가했습니다.
- Caffeine 기반 deduplication을 도입하고, 원자적 획득 로직으로 동시성 제어와 중복 알림 방지를 함께 처리했습니다.
- HTTP 요청 컨텍스트에서 method/path를 MDC에 기록해 Slack 메시지에 포함할 수 있도록 했습니다.
- Slack webhook 호출용 sender와 payload DTO를 추가했고, 핵심 장애 정보가 attachment가 아닌 최상위 `text`에도 담기도록 메시지 포맷을 정리했습니다.

### 변경/추가된 프로젝트 구조
```text
contract-service
├─ src/main/java/com/example/contractservice/common/filter
│  └─ MDCFilter.java
├─ src/main/java/com/example/contractservice/common/logging
│  ├─ CaffeineErrorDeduplicator.java
│  ├─ SlackErrorAppender.java
│  ├─ SlackErrorDeduplicator.java
│  └─ SlackSender.java
├─ src/main/java/com/example/contractservice/common/logging/dto
│  └─ SlackErrorInfo.java
├─ src/main/resources
│  └─ logback-spring.xml
└─ build.gradle
```

### 핵심 로직
핵심 로직 1 - `ERROR` 로그를 Slack 전용 appender로 분기
- 파일/콘솔 로깅은 유지하면서, `ERROR` 레벨만 별도 경로로 보내도록 구성했습니다.
- 운영 중 장애 알림 채널을 로깅 설정 레벨에서 분리해 애플리케이션 코드 변경 없이 일관된 알림 경로를 확보합니다.

```xml
<appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
        <level>ERROR</level>
    </filter>
    <appender-ref ref="SLACK_ERROR_ALERT" />
</appender>
```

핵심 로직 2 - 동시성 제어를 통해 중복 알림 방지
- dedupe key를 기준으로 일정 시간 내 동일 에러는 재전송하지 않도록 했습니다.
- `putIfAbsent` 기반의 원자적 획득으로 여러 스레드에서 같은 장애가 동시에 들어와도 최초 1회만 알림이 전송되도록 했습니다.
- Slack 전송 실패 시 key를 제거해 다음 동일 장애는 다시 알림을 시도할 수 있도록 했습니다.

```java
@Override
public boolean acquire(String key) {
    return cache.asMap().putIfAbsent(key, Boolean.TRUE) == null;
}
```

핵심 로직 3 - 요청 컨텍스트와 예외 정보를 AI가 읽기 쉬운 메시지로 정리
- HTTP 요청에서 발생한 예외는 method/path를 MDC로 전달하고, 예외 요약과 root cause 정보를 Slack 메시지 최상위 `text`에 담도록 구성했습니다.
- 비 HTTP 컨텍스트에서는 요청 문구를 생략해 `예외 발생` 형태로 단순화하고, attachment 의존 없이도 장애 원문을 바로 읽을 수 있게 했습니다.

### 성능 또는 안정성 설명
- Caffeine TTL 기반 deduplication으로 같은 장애가 짧은 시간 안에 반복될 때 Slack 채널이 과도한 알림으로 오염되는 문제를 줄입니다.
- `putIfAbsent` 기반 원자 연산으로 동시 다발적인 `ERROR` 로그 상황에서도 중복 알림 전송을 억제합니다.
- `AsyncAppender`로 Slack 전송을 비동기 경로로 분리해 일반 로깅과 파일 기록은 유지하면서 외부 webhook 호출을 별도 큐에서 처리합니다.
- Slack 메시지 핵심 정보를 최상위 `text`에 배치해, attachment를 읽지 않는 외부 소비자나 후속 자동화가 장애 내용을 놓치지 않도록 했습니다.
- 실패 시 dedupe key를 제거하도록 해 일시적 Slack 전송 실패가 장시간 알림 누락으로 이어지지 않도록 했습니다.

## 🧪 테스트 방법
- 자동 테스트
  - `.\gradlew.bat test`
  - JDK 17 환경에서 전체 모듈 테스트를 최신 커밋 기준으로 실행했고 통과했습니다.
- 확인 포인트
  - 애플리케이션 구동 시 `logback-spring.xml`이 로드되는지
  - `ERROR` 로그 발생 시 파일 로그와 Slack 경로가 함께 동작하는지
  - 동일 에러 반복 시 deduplication이 적용되는지
  - Slack 메시지 본문에서 attachment 없이도 예외 요약과 root cause를 바로 읽을 수 있는지

## 📎 참고 사항
- 관련 이슈 번호 : 12
- 현재 브랜치(`feat/contract/12`)는 `develop` 대상으로 열린 PR #13에 반영 중입니다.
- Slack webhook 경로와 timeout/deduplication TTL은 설정값으로 조정 가능하도록 구성했습니다.
- 테스트 실행 시 Kafka listener 종료 로그가 출력되지만, 최신 전체 테스트(`.\gradlew.bat test`)는 정상 통과했습니다.
- @codex
- @claude

## 📝 제출자 검토 리스트

- [x] 실행 시 오류가 없나요?
- [x] 테스트 전부 통과 했나요?
- [x] 이슈 번호를 입력 했나요?
- [x] 코드 컨벤션을 모두 지켰나요?
- [x] 브랜치가 develop에 merge 요청을 보냈나요?

## 📝 검토자 체크 리스트

> [!IMPORTANT]
> 직접 모든 부분에 대해 검토하고 멘션이나 이모티콘 남겨주세요

- [ ] 요청을 받은 후 하루 이내에 피드백을 보내주세요
- [ ] 본인이 검토해야하는 PR 피드백을 주세요.
- [ ] 브랜치가 develop에 merge 요청을 보냈나요?
